### PR TITLE
Case correction on examples

### DIFF
--- a/examples/06.Synthesis/AMsynth/AMsynth.ino
+++ b/examples/06.Synthesis/AMsynth/AMsynth.ino
@@ -20,7 +20,7 @@
 //#include <ADC.h>  // Teensy 3.0/3.1 uncomment this line and install http://github.com/pedvide/ADC
 #include <MozziGuts.h>
 #include <Oscil.h>
-#include <tables/COS2048_int8.h> // table for Oscils to play
+#include <tables/cos2048_int8.h> // table for Oscils to play
 //#include <mozzi_utils.h>
 #include <mozzi_fixmath.h>
 #include <EventDelay.h>

--- a/examples/06.Synthesis/AMsynth_HIFI/AMsynth_HIFI.ino
+++ b/examples/06.Synthesis/AMsynth_HIFI/AMsynth_HIFI.ino
@@ -45,7 +45,7 @@
 
 #include <MozziGuts.h>
 #include <Oscil.h>
-#include <tables/COS2048_int8.h> // table for Oscils to play
+#include <tables/cos2048_int8.h> // table for Oscils to play
 #include <mozzi_fixmath.h>
 #include <EventDelay.h>
 #include <mozzi_rand.h>


### PR DESCRIPTION
Case sensitive filesystems (as on Linux) won't find COS2048_int8.h, but will work with cos2048_int8.h