### PR TITLE
Silence some warnings

### DIFF
--- a/MozziGuts.h
+++ b/MozziGuts.h
@@ -33,7 +33,7 @@ to become impractical is around 1024. 64, 128, 256 and sometimes 512 are all
 usable values. Try to keep it as low as you can, for efficiency, though higher
 rates can sometimes give smoother results, avoiding the need to interpolate
 sensitive variables at audio rate in updateAudio(). CONTROL_RATE has a default
-of 64 Hz, but it can be changed at the top of your sketch, after the \#includes,
+of 64 Hz, but it can be changed at the top of your sketch, (before the \#includes),
 for example: \#define CONTROL_RATE 256
 */
 #define CONTROL_RATE 64

--- a/MozziGuts.h
+++ b/MozziGuts.h
@@ -24,6 +24,7 @@
 
 #include "mozzi_analog.h"
 
+#if not defined (CONTROL_RATE)
 /** @ingroup core
 Control rate setting.
 Mozzi's CONTROL_RATE sets how many times per second updateControl() is called.
@@ -36,6 +37,7 @@ of 64 Hz, but it can be changed at the top of your sketch, after the \#includes,
 for example: \#define CONTROL_RATE 256
 */
 #define CONTROL_RATE 64
+#endif
 
 
 
@@ -147,16 +149,6 @@ HIFI is not available/not required on Teensy 3.1.
 
 
 #include "mozzi_config.h" // User can change the config file to set audio mode
-
-
-// Print warning/reminder about the AUDIO_MODE setting to the arduino console while compiling
-#if AUDIO_MODE == STANDARD
-#warning "AUDIO_MODE is set to STANDARD in mozzi_config.h.  If things sound wrong, check if STANDARD is the correct AUDIO_MODE for your sketch."
-#elif AUDIO_MODE == STANDARD_PLUS
-#warning "AUDIO_MODE is set to STANDARD_PLUS in mozzi_config.h.  If things sound wrong, check if STANDARD_PLUS is the correct AUDIO_MODE for your sketch."
-#elif AUDIO_MODE == HIFI
-#warning "AUDIO_MODE is set to HIFI in mozzi_config.h.  If things sound wrong, check if HIFI is the correct AUDIO_MODE for your sketch."
-#endif
 
 #if (AUDIO_MODE == STANDARD) && (AUDIO_RATE == 32768)
 #error AUDIO_RATE 32768 does not work when AUDIO_MODE is STANDARD, try setting the AUDIO_MODE to STANDARD_PLUS in Mozzi/mozzi_config.h


### PR DESCRIPTION
This patch removes two warnings that are shown on compiling (almost) every Mozzi sketch.

The first is about redefinition of CONTROL_RATE. The documentation states that this can be overridden, explicitly, but the compiler will still generate a warning in this case. The patch removes the warning - if, and only if - CONTROL_RATE is defined _before_ including MozziGuts.h. If control rate is defined _after_ including MozziGuts.h, a warning will still be generated, but the behavior will continue to be just as before.

The second part of the sketch removes the unconditional warning about the audio setup. I understand these warnings were added, intentionally, and probably for good reason. However, having them around all of the time is a distraction from "real" warnings: Once you get used to the fact that there's always "something red" in the output, you'll stop reading it on each iteration. Also, there are certainly more things that can go wrong besides the AUDIO_MODE. Finally, I guess users proficient enough to enable and read compiler warnings, are probably also proficient enough to read the FAQ.
