### PR TITLE
Explicitly specify 16 bit ints for audio output bits and analog readings

### DIFF
--- a/MozziGuts.cpp
+++ b/MozziGuts.cpp
@@ -73,9 +73,9 @@ PWM frequency tests
 
 //-----------------------------------------------------------------------------------------------------------------
 // ring buffer for audio output
-CircularBuffer <unsigned int> output_buffer; // fixed size 256
+CircularBuffer <uint16_t> output_buffer; // fixed size 256
 #if (STEREO_HACK == true)
-CircularBuffer <unsigned int> output_buffer2; // fixed size 256
+CircularBuffer <uint16_t> output_buffer2; // fixed size 256
 #endif
 //-----------------------------------------------------------------------------------------------------------------
 
@@ -251,10 +251,10 @@ void audioHook() // 2us excluding updateAudio()
 	if (!output_buffer.isFull()) {
 		#if (STEREO_HACK == true)
 		updateAudio(); // in hacked version, this returns void
-		output_buffer.write((unsigned int) (audio_out_1 + AUDIO_BIAS));
-		output_buffer2.write((unsigned int) (audio_out_2 + AUDIO_BIAS));
+		output_buffer.write((uint16_t) (audio_out_1 + AUDIO_BIAS));
+		output_buffer2.write((uint16_t) (audio_out_2 + AUDIO_BIAS));
 		#else
-		output_buffer.write((unsigned int) (updateAudio() + AUDIO_BIAS));
+		output_buffer.write((uint16_t) (updateAudio() + AUDIO_BIAS));
 		#endif
 
 	}

--- a/MozziGuts.h
+++ b/MozziGuts.h
@@ -264,10 +264,10 @@ calculations here which could be done in setup() or updateControl().
 In HIFI mode, it's a 14 bit number between -16384 and 16383 inclusive.
 */
 #if (STEREO_HACK == true)
-extern int audio_out_1, audio_out_2;
+extern int16_t audio_out_1, audio_out_2;
 void updateAudio();
 #else
-int updateAudio();
+int16_t updateAudio();
 #endif
 
 /** @ingroup core
@@ -312,7 +312,7 @@ http://www.instructables.com/id/Arduino-Audio-Input/?ALLSTEPS
 @return audio data from the input buffer
 */
 #if (USE_AUDIO_INPUT == true)
-int getAudioInput();
+int16_t getAudioInput();
 #endif
 
 

--- a/mozzi_analog.cpp
+++ b/mozzi_analog.cpp
@@ -193,7 +193,7 @@ jRaskell, bobgardner, theusch, Koshchi, and code by jRaskell.
 http://www.avrfreaks.net/index.php?name=PNphpBB2&file=viewtopic&p=789581
 */
 
-static volatile int analog_readings[NUM_ANALOG_INPUTS];
+static volatile int16_t analog_readings[NUM_ANALOG_INPUTS];
 static Stack <volatile int8_t,NUM_ANALOG_INPUTS> adc_channels_to_read;
 volatile static int8_t current_channel = -1; // volatile because accessed in control and adc ISRs
 static bool first = true;
@@ -223,7 +223,7 @@ void adcReadSelectedChannels() {
 
 
 
-int mozziAnalogRead(uint8_t pin) {
+int16_t mozziAnalogRead(uint8_t pin) {
 // ADC lib converts pin/channel in startSingleRead
 #if IS_AVR()
 	pin = adcPinToChannelNum(pin); // allow for channel or pin numbers

--- a/mozzi_analog.h
+++ b/mozzi_analog.h
@@ -172,7 +172,7 @@ interrupt.
 @return the digitised value of the voltage on the chosen channel, in the range 0-1023. @Note that non-AVR
 hardware may return a different range, e.g. 0-4095 on STM32 boards.
 */
-int mozziAnalogRead(uint8_t pin);
+int16_t mozziAnalogRead(uint8_t pin);
 
 
 /* Used in MozziGuts.cpp, in updateControlWithAutoADC() to kick off any mozziAnalogReads waiting on the stack


### PR DESCRIPTION
While playing with adding a larger audio output buffer (I thought it might help at higher audio rates, but did not actually reduce my troubles), I noted that on the 32bit platforms, the audio output buffer uses 32bit storage, as "int" is 32bit wide, here. This causes a waste of 512 bytes of RAM right there (twice as much for stereo) while adding virtually no benefit (to be entirely precise, using 32bit storage will be minimally faster, due to being already aligned, but the overhead of unaligned data is negligible compared to overhead of the timer interrupt; however, 512 bytes of RAM is not negligible in most cases).

This patch changes that to int16_t. On AVR boards, this does not make any difference. **On Teensy 3.x and STM32, existing sketches will break** as the signature of "int updateAudio()" is not the same as "int16_t updateAudio()", here.

The patch also addresses a similar issue in mozziAnalogRead(), although the amount of RAM saved is much smaller, here (but also sketches will remain source compatible in that respect).