### PR TITLE
Trigger updateControl from within audioHook(), rather than from timer.

### DIFF
--- a/ADSR.h
+++ b/ADSR.h
@@ -17,7 +17,6 @@
 #else
  #include "WProgram.h"
 #endif
-//#include <util/atomic.h>
 #include "Line.h"
 #include "mozzi_fixmath.h"
 

--- a/AudioConfigSTM32.h
+++ b/AudioConfigSTM32.h
@@ -8,9 +8,8 @@
 // Audio output pin. If you want to change this, make sure to also set AUDIO_PWM_TIMER to whichever timer is responsible for your PWM pin, and set the other timers to non-conflicting values
 #define AUDIO_CHANNEL_1_PIN PB8
 #define AUDIO_PWM_TIMER 4
-// The timers used for running the control and audio update loops
-#define CONTROL_UPDATE_TIMER 3
-#define AUDIO_UPDATE_TIMER 2
+// The timer used for running the audio update loop
+#define AUDIO_UPDATE_TIMER 3
 
 #if (AUDIO_MODE == HIFI)
 // Second out pin for HIFI mode. This must be on the same timer as AUDIO_CHANNEL_1_PIN!

--- a/EventDelay.h
+++ b/EventDelay.h
@@ -13,7 +13,7 @@
 #define EVENTDELAY_H_
 
 
-/** A non-blocking replacement for Arduino's delay() function (which is disabled by Mozzi). 
+/** A non-blocking replacement for Arduino's delay() function. 
 EventDelay can be set() to a number of milliseconds, then after calling start(), ready() will return true when the time is up.  
 Alternatively, start(milliseconds) will call set() and start() together.
 */

--- a/Line.h
+++ b/Line.h
@@ -17,7 +17,6 @@
 #else
  #include "WProgram.h"
 #endif
-#include <util/atomic.h>
 
 /** For linear changes with a minimum of calculation at each step. For instance,
 you can use Line to make an oscillator glide from one frequency to another,
@@ -58,10 +57,7 @@ public:
 	inline
 	T next()
 	{
-		ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
-		{
-			current_value += step_size;
-		}
+		current_value += step_size;
 		//Serial.println(current_value);
 		return current_value;
 	}
@@ -76,10 +72,7 @@ public:
 	inline
 	void set(T value)
 	{
-		ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
-		{
-			current_value=value;
-		}
+		current_value=value;
 	}
 
 
@@ -92,16 +85,10 @@ public:
 	void set(T targetvalue, T num_steps)
 	{
 		T numerator;
-//		ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
-//		{
-		 numerator = targetvalue-current_value;
-//		}
+		numerator = targetvalue-current_value;
 		//float step = (float)numerator/num_steps;
 			T step = numerator/num_steps;
-//		ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
-//		{
-			step_size= (T)step;
-//		}
+		step_size= (T)step;
 		//Serial.print("numerator");Serial.print(" \t");Serial.println(numerator);
 		//Serial.print("num_steps");Serial.print(" \t");Serial.println(num_steps);
 		//Serial.print(step);Serial.print(" \t");Serial.println(step_size);
@@ -148,10 +135,7 @@ public:
 	inline
 	unsigned char next()
 	{
-		ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
-		{
-			current_value += step_size;
-		}
+		current_value += step_size;
 		return current_value;
 	}
 
@@ -165,10 +149,7 @@ public:
 	inline
 	void set(unsigned char value)
 	{
-		ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
-		{
-			current_value=value;
-		}
+		current_value=value;
 	}
 
 
@@ -223,10 +204,7 @@ public:
 	inline
 	unsigned int next()
 	{
-		ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
-		{
-			current_value += step_size;
-		}
+		current_value += step_size;
 		return current_value;
 	}
 
@@ -240,10 +218,7 @@ public:
 	inline
 	void set(unsigned int value)
 	{
-		ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
-		{
-			current_value=value;
-		}
+		current_value=value;
 	}
 
 
@@ -301,10 +276,7 @@ public:
 	inline
 	unsigned long next()
 	{
-		ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
-		{
-			current_value += step_size;
-		}
+		current_value += step_size;
 		return current_value;
 	}
 
@@ -318,10 +290,7 @@ public:
 	inline
 	void set(unsigned long value)
 	{
-		ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
-		{
-			current_value=value;
-		}
+		current_value=value;
 	}
 
 

--- a/MozziGuts.cpp
+++ b/MozziGuts.cpp
@@ -23,7 +23,6 @@
 //#include "mozzi_utils.h"
 
 #if IS_AVR()
-#include "TimerZero.h"
 #include "TimerOne.h"
 #include "FrequencyTimer2.h"
 #elif IS_TEENSY3()
@@ -82,7 +81,6 @@ CircularBuffer <unsigned int> output_buffer2; // fixed size 256
 #if IS_AVR() // not storing backups, just turning timer on and off for pause for teensy 3, 3.1, other ARMs
 
 // to store backups of timer registers so Mozzi can be stopped and pre_mozzi timer values can be restored
-static uint8_t pre_mozzi_TCCR0A, pre_mozzi_TCCR0B, pre_mozzi_OCR0A, pre_mozzi_TIMSK0;
 static uint8_t pre_mozzi_TCCR1A, pre_mozzi_TCCR1B, pre_mozzi_OCR1A, pre_mozzi_TIMSK1;
 
 #if (AUDIO_MODE == HIFI)
@@ -110,7 +108,6 @@ static void backupPreMozziTimer1()
 
 
 // to store backups of mozzi's changes to timer registers so Mozzi can be paused and unPaused
-static uint8_t mozzi_TCCR0A, mozzi_TCCR0B, mozzi_OCR0A, mozzi_TIMSK0;
 static uint8_t mozzi_TCCR1A, mozzi_TCCR1B, mozzi_OCR1A, mozzi_TIMSK1;
 
 #if (AUDIO_MODE == HIFI)
@@ -575,48 +572,10 @@ static void updateControlWithAutoADC()
 }
 
 
-/* Sets up Timer 0 for control interrupts. This is the same for all output
-options Using Timer0 for control disables Arduino's time functions but also
-saves on the interrupts and blocking action of those functions. May add a config
-option for Using Timer2 instead if needed. (MozziTimer2 can be re-introduced for
-that). */
-#if IS_TEENSY3()
-IntervalTimer timer0;
-#elif IS_STM32()
-HardwareTimer control_timer(CONTROL_UPDATE_TIMER);
-#endif
-
-
 static void startControl(unsigned int control_rate_hz)
 {
 	update_control_counter = 0;
         update_control_timeout = AUDIO_RATE / control_rate_hz;
-#if IS_AVR()
-	// backup pre-mozzi register values
-	pre_mozzi_TCCR0A = TCCR0A;
-	pre_mozzi_TCCR0B = TCCR0B;
-	pre_mozzi_OCR0A = OCR0A;
-	pre_mozzi_TIMSK0 = TIMSK0;
-
-//	TimerZero::init(1000000/control_rate_hz,updateControlWithAutoADC); // set period, attach updateControlWithAutoADC()
-//	TimerZero::start();
-
-	// backup mozzi register values for unpausing later
-	mozzi_TCCR0A = TCCR0A;
-	mozzi_TCCR0B = TCCR0B;
-	mozzi_OCR0A = OCR0A;
-	mozzi_TIMSK0 = TIMSK0;
-#elif IS_TEENSY3()
-//	timer0.begin(updateControlWithAutoADC, 1000000/control_rate_hz);
-#else
-	control_timer.pause();
-	control_timer.setPeriod(1000000/control_rate_hz);
-	control_timer.setChannel1Mode(TIMER_OUTPUT_COMPARE);
-	control_timer.setCompare(TIMER_CH1, 1);
-//	control_timer.attachCompare1Interrupt(updateControlWithAutoADC);
-	control_timer.refresh();
-	control_timer.resume();
-#endif
 }
 
 void startMozzi(int control_rate_hz)
@@ -638,22 +597,15 @@ void stopMozzi(){
 	timer1.end();
 #elif IS_STM32()
         audio_update_timer.pause();
-        control_timer.pause();
 #else
 
     noInterrupts();
 	
 	// restore backed up register values
-	TCCR0A = pre_mozzi_TCCR0A;
-	TCCR0B = pre_mozzi_TCCR0B;
-	OCR0A = pre_mozzi_OCR0A;
-
-
 	TCCR1A = pre_mozzi_TCCR1A;
 	TCCR1B = pre_mozzi_TCCR1B;
 	OCR1A = pre_mozzi_OCR1A;
 
-	TIMSK0 = pre_mozzi_TIMSK0;
 	TIMSK1 = pre_mozzi_TIMSK1;
 
 #if (AUDIO_MODE == HIFI)

--- a/MozziGuts.cpp
+++ b/MozziGuts.cpp
@@ -15,7 +15,6 @@
  #include "WProgram.h"
 #endif
 
-#include <util/atomic.h>
 #include "MozziGuts.h"
 #include "mozzi_config.h" // at the top of all MozziGuts and analog files
 #include "mozzi_analog.h"

--- a/MozziGuts.h
+++ b/MozziGuts.h
@@ -203,9 +203,11 @@ Sets up the timers for audio and control rate processes, storing the timer
 registers so they can be restored when Mozzi stops. startMozzi() goes in your sketch's
 setup() routine.
 
-In STANDARD_PLUS and HIFI modes, Mozzi uses Timer 0 for control interrupts, disabling Arduino
-delay(), millis(), micros() and delayMicroseconds(). 
-For delaying events, you can use Mozzi's EventDelay() unit instead (not to be confused with AudioDelay()). 
+Contrary to earlier versions of Mozzi, this version does not take over Timer 0, and thus Arduino
+functions delay(), millis(), micros() and delayMicroseconds() remain usable in theory. That said,
+you should avoid these functions, as they are slow (or even blocking). For measuring time, refer
+to mozziMircos(). For delaying events, you can use Mozzi's EventDelay() unit instead
+(not to be confused with AudioDelay()).
 
 In STANDARD mode, startMozzi() starts Timer 1 for PWM output and audio output interrupts,
 and in STANDARD_PLUS and HIFI modes, Mozzi uses Timer 1 for PWM and Timer2 for audio interrupts. 
@@ -229,9 +231,8 @@ void startMozzi(int control_rate_hz = CONTROL_RATE);
 
 /** @ingroup core
 Stops audio and control interrupts and restores the timers to the values they
-had before Mozzi was started. This will enable the standard Arduino time
-functions millis(), micros(), delay(), and delayMicroseconds(). This could be
-useful when using sensor libraries which depend on the same timers as Mozzi. 
+had before Mozzi was started. This could be useful when using sensor libraries
+which depend on the same timers as Mozzi.
 
 A potentially better option for resolving timer conflicts involves using
 non-blocking methods, such as demonstrated by the twowire_nonblock code in the
@@ -241,17 +242,14 @@ reading sensors.
 As it is, stopMozzi restores all the Timers used by Mozzi to their previous
 settings. Another scenario which could be easily hacked in MozziGuts.cpp could
 involve individually saving and restoring particular Timer registers depending
-on which one(s) are required for other tasks, so for example the control
-interrupt (Timer 0) could be suspended while audio continues.*/
+on which one(s) are required for other tasks. */
 void stopMozzi();
 
 
 // TB2017 deleted function, use startMozzi() instead
 // /** @ingroup core
 // Restores Mozzi audio and control interrupts, if they have been temporarily
-// disabled with pauseMozzi(). This once more takes over Timer 0, and stops the
-// Arduino time functions millis(), micros(), delay(), and delayMicroseconds() from
-// working.
+// disabled with pauseMozzi().
 // */
 // void unPauseMozzi();
 
@@ -317,8 +315,10 @@ int getAudioInput();
 
 
 /** @ingroup core
-An alternative for Arduino time funcitions like micros() which are disabled by Mozzi when it takes over
-Timer 0 for control interrupts. audioTicks() is updated each time an audio sample
+An alternative for Arduino time functions like micros() and millis(). This is slightly faster than micros(),
+and also it is synchronized with the currently processed audio sample (which, due to the audio
+output buffer, could diverge up to 256/AUDIO_RATE seconds from the current time).
+audioTicks() is updated each time an audio sample
 is output, so the resolution is 1/AUDIO_RATE microseconds (61 microseconds when AUDIO_RATE is
 16384 Hz).
 @return the number of audio ticks since the program began.
@@ -328,9 +328,11 @@ unsigned long audioTicks();
 
 
 /** @ingroup core
-A replacement for Arduino micros() which is disabled by Mozzi which takes over
-Timer 0 for control interrupts. mozziMicros is updated each time an audio sample
-is output, so the resolution is 1/AUDIO_RATE (61 microseconds when AUDIO_RATE is
+An alternative for Arduino time functions like micros() and millis(). This is slightly faster than micros(),
+and also it is synchronized with the currently processed audio sample (which, due to the audio
+output buffer, could diverge up to 256/AUDIO_RATE seconds from the current time).
+audioTicks() is updated each time an audio sample
+is output, so the resolution is 1/AUDIO_RATE microseconds (61 microseconds when AUDIO_RATE is
 16384 Hz).
 @return the approximate number of microseconds since the program began.
 @todo  incorporate mozziMicros() in a more accurate EventDelay()?

--- a/MultiLine.h
+++ b/MultiLine.h
@@ -17,7 +17,6 @@
 #else
  #include "WProgram.h"
 #endif
-//#include <util/atomic.h>
 #include "Line.h"
 #include "mozzi_fixmath.h"
 

--- a/MultiLine2.h
+++ b/MultiLine2.h
@@ -17,7 +17,6 @@
 #else
  #include "WProgram.h"
 #endif
-//#include <util/atomic.h>
 #include "Line.h"
 #include "mozzi_fixmath.h"
 

--- a/Phasor.h
+++ b/Phasor.h
@@ -18,7 +18,6 @@
  #include "WProgram.h"
 #endif
 #include "mozzi_fixmath.h"
-#include <util/atomic.h>
 
 #define PHASOR_MAX_VALUE_UL 4294967295UL
 
@@ -50,10 +49,7 @@ public:
 	inline
 	unsigned long next()
 	{
-		ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
-		{
-			current_value += step_size; // will wrap
-		}
+		current_value += step_size; // will wrap
 		return current_value;
 	}
 
@@ -86,11 +82,7 @@ public:
 	inline
 	void setFreq(float frequency)
 	{ // 1 us - using float doesn't seem to incur measurable overhead with the oscilloscope
-		//ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
-		//{
 		step_size = (unsigned long)(((float)PHASOR_MAX_VALUE_UL/UPDATE_RATE)*frequency);
-
-		//}
 	}
 
 	/** phaseIncFromFreq() and setPhaseInc() are for saving processor time when sliding between frequencies.
@@ -115,10 +107,7 @@ public:
 	inline
 	void setPhaseInc(unsigned long stepsize)
 	{
-		ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
-		{
-			step_size = stepsize;
-		}
+		step_size = stepsize;
 	}
 
 };

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ real DAC. Should probably run on any other board supported by [STM32duino](https
 - You will need a very recent (12/2017) checkout of the Arduino_STM32 repository, otherwise compilation will fail.
 - Audio output is to pin PB8, by default (HIFI-mode: PB8 and PB9)
 - If you want to use MIDI, be sure to replace "MIDI_CREATE_DEFAULT_INSTANCE()" with "MIDI_CREATE_INSTANCE(HardwareSerial, Serial1, MIDI)" (or Serial2)
-- Timers 4 (PWM output), 2 (control rate), and 3 (audio rate) are used. Timers 2 and 3 could certainly be merged, but I did not bother optimizing, yet.
+- Timers 4 (PWM output), and 3 (audio rate) are used.
 - Default audio resolution is currently set to 10 bits, which yields 70khZ PWM frequency on a 72MHz CPU. HIFI mode is 2*7bits at up to 560Khz (but limited to 5 times audio rate)
 - HIFI_MODE did not get much testing
 - STEREO_HACK not yet implemented (although that should not be too hard to do)

--- a/Sample.h
+++ b/Sample.h
@@ -16,7 +16,6 @@
 
 #include "MozziGuts.h"
 #include "mozzi_fixmath.h"
-#include <util/atomic.h>
 
 // fractional bits for sample index precision
 #define SAMPLE_F_BITS 16
@@ -102,11 +101,7 @@ public:
 	inline
 	void start()
 	{
-		// atomic because start() can be called on a sample in the control interrupt
-		ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
-		{
-			phase_fractional = startpos_fractional;
-		}
+		phase_fractional = startpos_fractional;
 	}
 
 
@@ -229,10 +224,7 @@ public:
 	*/
 	inline
 	void setFreq (int frequency) {
-		ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
-		{
-			phase_increment_fractional = ((((unsigned long)NUM_TABLE_CELLS<<ADJUST_FOR_NUM_TABLE_CELLS)*frequency)/UPDATE_RATE) << (SAMPLE_F_BITS - ADJUST_FOR_NUM_TABLE_CELLS);
-		}
+		phase_increment_fractional = ((((unsigned long)NUM_TABLE_CELLS<<ADJUST_FOR_NUM_TABLE_CELLS)*frequency)/UPDATE_RATE) << (SAMPLE_F_BITS - ADJUST_FOR_NUM_TABLE_CELLS);
 	}
 
 
@@ -244,10 +236,7 @@ public:
 	inline
 	void setFreq(float frequency)
 	{ // 1 us - using float doesn't seem to incur measurable overhead with the oscilloscope
-		ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
-		{
-			phase_increment_fractional = (unsigned long)((((float)NUM_TABLE_CELLS * frequency)/UPDATE_RATE) * SAMPLE_F_BITS_AS_MULTIPLIER);
-		}
+		phase_increment_fractional = (unsigned long)((((float)NUM_TABLE_CELLS * frequency)/UPDATE_RATE) * SAMPLE_F_BITS_AS_MULTIPLIER);
 	}
 
 
@@ -262,12 +251,9 @@ public:
 	inline
 	void setFreq_Q24n8(Q24n8 frequency)
 	{
-		ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
-		{
-			//phase_increment_fractional = (frequency* (NUM_TABLE_CELLS>>3)/(UPDATE_RATE>>6)) << (F_BITS-(8-3+6));
-			phase_increment_fractional = (((((unsigned long)NUM_TABLE_CELLS<<ADJUST_FOR_NUM_TABLE_CELLS)>>3)*frequency)/(UPDATE_RATE>>6))
+		//phase_increment_fractional = (frequency* (NUM_TABLE_CELLS>>3)/(UPDATE_RATE>>6)) << (F_BITS-(8-3+6));
+		phase_increment_fractional = (((((unsigned long)NUM_TABLE_CELLS<<ADJUST_FOR_NUM_TABLE_CELLS)>>3)*frequency)/(UPDATE_RATE>>6))
 			                             << (SAMPLE_F_BITS - ADJUST_FOR_NUM_TABLE_CELLS - (8-3+6));
-		}
 	}
 
 
@@ -305,10 +291,7 @@ public:
 	inline
 	void setPhaseInc(unsigned long phaseinc_fractional)
 	{
-		ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
-		{
-			phase_increment_fractional = phaseinc_fractional;
-		}
+		phase_increment_fractional = phaseinc_fractional;
 	}
 
 

--- a/SampleHuffman.h
+++ b/SampleHuffman.h
@@ -44,8 +44,6 @@ The other is "HUFFMAN" which must also fit into Flash RAM
 
 */
 
-#include <util/atomic.h>
-
 class SampleHuffman
 {
 
@@ -106,13 +104,9 @@ public:
 	inline
 	void start()
 	{
-		// atomic because start() can be called on a sample in the control interrupt
-		ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
-		{
-			current = 0;
-			datapos = 0;
-			bt = 0;
-		}
+		current = 0;
+		datapos = 0;
+		bt = 0;
 	}
 	
 private:

--- a/StateVariable.h
+++ b/StateVariable.h
@@ -45,7 +45,6 @@ Jon Dattorro, Effect Design Part 1, J. Audio Eng. Soc., Vol 45, No. 9, 1997 Sept
 #define STATEVARIABLE_H_
 
 #include "Arduino.h"
-#include "util/atomic.h"
 #include "mozzi_fixmath.h"
 #include "math.h"
 #include "mozzi_utils.h"
@@ -87,10 +86,7 @@ public:
 		// qvalue goes from 255 to 0, representing .999 to 0 in fixed point
 		// lower q, more resonance
 		q = resonance;
-		//ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
-		//{
 		scale = (Q0n8)sqrt((unsigned int) resonance<<8);
-		//}
 	}
 
 


### PR DESCRIPTION
Ok, this one is definitely just a discussion starter, rather than a real pull request. It works for me, beautifully, on both STM32 and a Pro Mini, but it's clearly a non-trivial change. Also, if you were to give the go-ahead to this one, it would mean that _a lot_ of code can be removed (everything about Timer 0, essentially).

But to start at the beginning: The starting point to this idea was that I was struggling with some IO latency issues while handling MIDI file playback (see http://www.stm32duino.com/viewtopic.php?f=19&t=3041&sid=dc7ca666b2b92884cde768b1f4de1728). In that context I began thinking about what parts of the processing I could move from updateControl() to the main loop. But then, I started wondering, why isn't updateControl() part of the main loop in the first place?

Reasons that I could think up were:
1. updateControl() needs to be called at a defined rate. --> True, but at least for audio updates, that rate would actually be defined in terms of audio-ticks, not absolute time. This patch moves from being as exact on the time as possible to being perfectly exact on the audio-tick.
2. updateControl() should be able to run in parallel with updateAudio(). --> Yes, that would be nice, but it isn't actually the case. updateAudio() may be interrupted by updateControl() at any point, _but_ not the other way around. Thus, whenever updateControl() is running, updateAudio() is already blocked. Nothing changes, here.
3. Audio output needs to be updated while updateControl() is running. --> Yes, and that works because the audio output is updated from an interrupt (on timer 1), _not_ because updateControl() is run from an interrupt. Nothing changes, here.
4. Users might be doing fancy stuff like keeping some IO buffers filled from the main loop, while updateControl() reads those. --> No, see 2. Main loop and updateControl() do not actually run in parallel, at all. Besides, now users will have one additional timer free to _really_ implement something like this.
5. ???

Other aspects:
- For now the code assumes that AUDIO_RATE is evenly divisible by control rate, but it would not be hard to handle a fractional ratio.
- Besides removing timer 0, the patch should also allow to remove most (all?) uses of ATOMIC_BLOCK. That and the fact that interrupt calling overhead is removed, should provide a minor boost to performance as a nice plus.
- I am not quite sure, why, but this change, alone, also helps a lot with the latency issues I was having with MIDI file playback (see above).

What do you think? If you agree on the principle, then I could put some work into removing obsolete code, and updating the docs.