### PR TITLE
New attempt: Allow to force an ADSR envelope back to zero on noteOn().

### DIFF
--- a/ADSR.h
+++ b/ADSR.h
@@ -170,10 +170,14 @@ public:
 
 
 
-	/** Start the attack phase of the ADSR.  THis will restart the ADSR no matter what phase it is up to.
+	/** Start the attack phase of the ADSR.  This will restart the ADSR no matter what phase it is up to.
+	@param reset If true, the envelope will start from 0, even if it is still playing (often useful for effect envelopes).
+	If false (default if omitted), the envelope will start rising from the current level, which could be non-zero, if
+	it is still playing (most useful for note envelopes).
 	*/
 	inline
-	void noteOn(){
+	void noteOn(bool reset=false){
+		if (reset) transition.set(0);
 		setPhase(&attack);
 		adsr_playing = true;
 	}


### PR DESCRIPTION
On further thought, you are absolutely right: Going back to zero level on noteOn(), _unconditionally_, is not desirable. For "normal" note amplitude envelopes, it will be best to continue from the current level, if a note is re-triggered while still playing (esp. during release). However, for other use cases of envelopes (effect envelopes), going back to zero may be much more desirable.

So the new attempt leaves the choice to the user, with explicit documentation.