### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -278,14 +278,14 @@ setIdleUpdateSteps	KEYWORD2
 setAllUpdateSteps	KEYWORD2
 
 
-Portamento KEYWORD1
+Portamento	KEYWORD1
 setTime	KEYWORD2
 start	KEYWORD2
 next	KEYWORD2
 
 
 DCfilter	KEYWORD1
-next KEYWORD2
+next	KEYWORD2
 
 
 RollingAverage	KEYWORD1


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords