### PR TITLE
Allow to skip ADC setup.

### DIFF
--- a/MozziGuts.cpp
+++ b/MozziGuts.cpp
@@ -680,9 +680,9 @@ static void startControl(unsigned int control_rate_hz)
         update_control_timeout = AUDIO_RATE / control_rate_hz;
 }
 
-void startMozzi(int control_rate_hz)
+void startMozzi(int control_rate_hz, ANALOG_READ_SPEED adc_speed)
 {
-	setupMozziADC(); // you can use setupFastAnalogRead() with FASTER or FASTEST in setup() if desired (not for Teensy 3.1)
+	setupMozziADC(adc_speed); // you can use setupFastAnalogRead() with FASTER or FASTEST in setup() if desired (not for Teensy 3.1)
 	// delay(200); // so AutoRange doesn't read 0 to start with
 	startControl(control_rate_hz);
 #if (AUDIO_MODE == STANDARD) || (AUDIO_MODE == STANDARD_PLUS) || IS_STM32()  // Sorry, this is really hacky. But on STM32 regular and HIFI audio modes are so similar to set up, that we do it all in one function.

--- a/MozziGuts.h
+++ b/MozziGuts.h
@@ -222,12 +222,15 @@ which has a default value of 64 (you can re-\#define it in your sketch).
 The practical upper limit for control rate depends on how busy the processor is,
 and you might need to do some tests to find the best setting.
 
+@param adc_speed Passed to setupMozziADC(). See the note, below.
+
 @note startMozzi calls setupMozziADC(), which calls setupFastAnalogRead() and adcDisconnectAllDigitalIns(), 
 which disables digital inputs on all analog input pins.  All in mozzi_analog.h and easy to change if you need to (hack).
 They are all called automatically and hidden away because it keeps things simple for a STANDARD_PLUS set up, 
-but if it turns out to be confusing, they might need to become visible again.
+but if it turns out to be confusing, they might need to become visible again. Use adc_speed=NO_SETUP_MOZZI_ADC to skip
+the ADC setup.
 */
-void startMozzi(int control_rate_hz = CONTROL_RATE);
+void startMozzi(int control_rate_hz = CONTROL_RATE, ANALOG_READ_SPEED adc_speed=FAST_ADC);
 
 
 

--- a/mozzi_analog.cpp
+++ b/mozzi_analog.cpp
@@ -56,7 +56,7 @@ void setupFastAnalogRead(int8_t speed)
 	// NOTE: These picks are pretty arbitrary. Further available options are 7_5, 28_5, 55_5, 71_5 and 239_5 (i.e. 7.5 ADC cylces, etc.)
 	if (speed == FASTEST_ADC) adc.setSampleRate(ADC_SMPR_1_5);
 	else if (speed == FASTER_ADC) adc.setSampleRate(ADC_SMPR_13_5);
-        else (adc.setSampleRate(ADC_SMPR_41_5));
+        else if (speed == FAST_ADC) (adc.setSampleRate(ADC_SMPR_41_5));
 #endif
 }
 
@@ -69,6 +69,7 @@ void adcEnableInterrupt(){
 
 
 void setupMozziADC(int8_t speed) {
+	if (speed == NO_SETUP_MOZZI_ADC) return;
 #if IS_TEENSY3()
 	adc = new ADC();
 	adc->enableInterrupts(ADC_0);

--- a/mozzi_analog.h
+++ b/mozzi_analog.h
@@ -66,7 +66,7 @@ static const uint8_t channel2sc1a[] = {
 
 
 // for setupFastAnalogRead()
-enum ANALOG_READ_SPEED {FAST_ADC,FASTER_ADC,FASTEST_ADC};
+enum ANALOG_READ_SPEED {FAST_ADC,FASTER_ADC,FASTEST_ADC,NO_SETUP_MOZZI_ADC};
 
 /** 
 @ingroup analog
@@ -92,10 +92,14 @@ void setupFastAnalogRead(int8_t speed=FAST_ADC);
 
 
 
-/*  @ingroup analog
+/**
+@ingroup analog
 Set up for asynchronous analog input, which enables analog reads to take 
 place in the background without blocking the processor.
 @param speed FAST_ADC, FASTER_ADC or FASTEST_ADC.  See setupFastAnalogRead();
+@note Specifying NO_SETUP_MOZZI_ADC for speed makes this function return, immediately. It
+does not undo the ADC setup. If you want to skip on ADC setup, be sure to include
+NO_SETUP_MOZZI_ADC in your call to startMozzi().
 */
 void setupMozziADC(int8_t speed=FAST_ADC);
 


### PR DESCRIPTION
E.g. for compatibility with certain libraries, or to enable techniques such as
analog port multiplexing.

Note that this is a run time solution. On the positive side, users can select to
skip ADC setup per sketch, without making any changes in the lib. On the negative side
(compared to a compile-time switch), this solution does not save any allocated RAM, and
the ISR routine is still defined on platforms that define it.

---- For some more background:
I had stumbled across this before. My present issue was that I tried to get a resistive touchscreen to work on an STM32F103C8T6, but this turned out to be impossible in conjunction with Mozzi. Use-cases like this are going to become more widespread on the more powerful platforms. But even on 8bit AVRs, there are cases, where users will need custom analogRead()s - e.g. from the PotMUX library.