### PR TITLE
Fixed AutoRange::AutoRange initialization and AutoRange::next behavior.

### DIFF
--- a/AutoRange.h
+++ b/AutoRange.h
@@ -24,7 +24,7 @@ public:
 	@param min_expected the minimum possible input value.
 	@param max_expected the maximum possible input value.
 	*/
-	AutoRange(T min_expected, T max_expected):range_min(max_expected),range_max(min_expected),range(0)
+	AutoRange(T min_expected, T max_expected):range_max(max_expected),range_min(min_expected),range(0)
 	{
 	}
 

--- a/AutoRange.h
+++ b/AutoRange.h
@@ -24,7 +24,7 @@ public:
 	@param min_expected the minimum possible input value.
 	@param max_expected the maximum possible input value.
 	*/
-	AutoRange(T min_expected, T max_expected):range_max(max_expected),range_min(min_expected),range(0)
+	AutoRange(T min_expected, T max_expected):org_range_max(max_expected),org_range_min(min_expected),range_max(max_expected),range_min(min_expected),range(0)
 	{
 	}
 
@@ -34,14 +34,14 @@ public:
 	*/
 	void next(T n)
 	{
-		if (n > range_max)
+		if (n >= org_range_max)
 		{
 			range_max = n;
 			range = range_max - range_min;
 		}
 		else
 		{
-			if (n< range_min)
+			if (n <= org_range_min)
 			{
 				range_min = n;
 				range = range_max - range_min;
@@ -76,6 +76,7 @@ public:
 	}
 
 private:
+	const T org_range_max, org_range_min;
 	T range_max, range_min, range;
 
 };


### PR DESCRIPTION
This following two fixes are contained in this PR:

1. Fixed an obvious bug in the initialization of AutoRange.
    
    The max_expected and min_expected values were initialized, firstly in
    the wrong order, and secondly the calling parameters were swapped,
    causing the AutoRange::max_expected to be initialized to min_expected
    and AutoRange::min_expected to be initialized to max_expected.

2. Fixes the overwriting of the original min and max ranges.
    
    The original max_expected and min_expected values were overwritten,
    causing the expected range to change and produced inconsistent return
    values from AutoRange::next().
