### PR TITLE
Revert "Fixed AutoRange::AutoRange initialization and AutoRange::next behavior."

### DIFF
--- a/AutoRange.h
+++ b/AutoRange.h
@@ -24,7 +24,7 @@ public:
 	@param min_expected the minimum possible input value.
 	@param max_expected the maximum possible input value.
 	*/
-	AutoRange(T min_expected, T max_expected):org_range_max(max_expected),org_range_min(min_expected),range_max(max_expected),range_min(min_expected),range(0)
+	AutoRange(T min_expected, T max_expected):range_min(max_expected),range_max(min_expected),range(0)
 	{
 	}
 
@@ -34,14 +34,14 @@ public:
 	*/
 	void next(T n)
 	{
-		if (n >= org_range_max)
+		if (n > range_max)
 		{
 			range_max = n;
 			range = range_max - range_min;
 		}
 		else
 		{
-			if (n <= org_range_min)
+			if (n< range_min)
 			{
 				range_min = n;
 				range = range_max - range_min;
@@ -76,7 +76,6 @@ public:
 	}
 
 private:
-	const T org_range_max, org_range_min;
 	T range_max, range_min, range;
 
 };


### PR DESCRIPTION
Reverts sensorium/Mozzi#56
The intended behaviour is to continually adjust range_max and range_min if incoming values lie outside the ranges.  The proposed change would only have updated max and min when they exceed the initialised values, instead of allowing them to grow each time they are exceeded.