### PR TITLE
Corrected wrong behavior leading to a wrong value of the starting point of the envelop when using very small values for the release time

### DIFF
--- a/ADSR.h
+++ b/ADSR.h
@@ -178,7 +178,7 @@ public:
 	*/
 	inline
 	void noteOn(bool reset=false){
-		if (reset) transition.set(0);
+		if (reset || !adsr_playing) transition.set(0);
 		setPhase(&attack);
 		adsr_playing = true;
 	}

--- a/ADSR.h
+++ b/ADSR.h
@@ -178,7 +178,7 @@ public:
 	*/
 	inline
 	void noteOn(bool reset=false){
-		if (reset || !adsr_playing) transition.set(0);
+		if (reset) transition.set(0);
 		setPhase(&attack);
 		adsr_playing = true;
 	}

--- a/Line.h
+++ b/Line.h
@@ -82,18 +82,15 @@ public:
 	@param num_steps how many steps to take to reach the target.
 	 */
 	inline
-	void set(T targetvalue, T num_steps)
+	  void set(T targetvalue, T num_steps)
 	{
-		T numerator;
-		numerator = targetvalue-current_value;
-		//float step = (float)numerator/num_steps;
-		T step = numerator/(num_steps ? num_steps : 1);
-		step_size= (T)step;
-		//Serial.print("numerator");Serial.print(" \t");Serial.println(numerator);
-		//Serial.print("num_steps");Serial.print(" \t");Serial.println(num_steps);
-		//Serial.print(step);Serial.print(" \t");Serial.println(step_size);
-		//step_size=(T)((((float)targetvalue-current_value)/num_steps));
-
+	  if(num_steps) {
+	    T numerator = targetvalue-current_value;
+	    step_size= numerator/num_steps;
+	  } else {
+	    step_size = 0;
+	    current_value = targetvalue;
+	  }
 	}
 
 	/** Given a new starting value, target value and the number of steps to take on the way, this sets the step size needed to get there.


### PR DESCRIPTION
Hi!

This corrects the fact that, when using very small values for the release time, the envelop may start, for a new note, on a non-zero value.
I think, even though the envelop is effectively reaching 0 at the end, the last point of the line (transition) used to interpolate points between sustain value do not reach zero and its last value is used for starting the envelop.

Note: this has been for very short (<20 micro) on STM32. Did not try to reproduce on AVR but I do not see why it would behave differently.

Sincerely,

T. Combriat