### PR TITLE
Added examples using DAC MCP49XX/48XX with Mozzi

### DIFF
--- a/examples/13.External_Audio_Output/FMsynth_MCP4921_mono_12bits/FMsynth_MCP4921_mono_12bits.ino
+++ b/examples/13.External_Audio_Output/FMsynth_MCP4921_mono_12bits/FMsynth_MCP4921_mono_12bits.ino
@@ -10,7 +10,7 @@
     MCP4921   //  Connect to:
     -------       -----------
     Vdd           V+
-    CS            any digital pin defined by SS_PIN (see after), or pin 10 on UNO / 11 on Mega if you are using Portwrite
+    CS            any digital pin defined by SS_PIN (see after), or pin 7 on UNO / 38 on Mega if you are using Portwrite
     SCK           SCK of Arduino
     SDI           MOSI of Arduino
     VoutA         to headphones/loudspeaker
@@ -60,7 +60,7 @@ Smooth <int> kSmoothNote(0.95f);
 
 
 // External audio output parameters and DAC declaration
-#define SS_PIN -1  // if you are on AVR and using PortWrite, you do not care what you put here.
+#define SS_PIN 38  // if you are on AVR and using PortWrite you need still need to put the pin you are actually using: 7 on Uno, 38 on Mega
 #define AUDIO_BIAS 2048  // we are at 12 bits, so we have to bias the signal of 2^(12-1) = 2048
 DAC_MCP49xx dac(DAC_MCP49xx::MCP4921, SS_PIN);
 

--- a/examples/13.External_Audio_Output/FMsynth_MCP4921_mono_12bits/FMsynth_MCP4921_mono_12bits.ino
+++ b/examples/13.External_Audio_Output/FMsynth_MCP4921_mono_12bits/FMsynth_MCP4921_mono_12bits.ino
@@ -1,0 +1,144 @@
+/*  Example of simple FM with the phase modulation technique,
+    using Mozzi sonification library and an external DAC MCP4921 (original library by Thomas Backman - https://github.com/exscape/electronics/tree/master/Arduino/Libraries/DAC_MCP49xx)
+    using an user-defined audioOutput() function.
+    Based on Mozzi's example: FMsynth.
+
+    #define EXTERNAL_AUDIO_OUTPUT true should be uncommented in mozzi_config.h.
+
+    Circuit: (see the DAC library README for details)
+
+    MCP4921   //  Connect to:
+    -------       -----------
+    Vdd           V+
+    CS            any digital pin defined by SS_PIN (see after), or pin 10 on UNO / 11 on Mega if you are using Portwrite
+    SCK           SCK of Arduino
+    SDI           MOSI of Arduino
+    VoutA         to headphones/loudspeaker
+    Vss           to GND
+    VrefA         to V+ or a clean tension ref between V+ and GND
+    LDAC          to GND
+
+
+		Mozzi documentation/API
+		https://sensorium.github.io/Mozzi/doc/html/index.html
+
+		Mozzi help/discussion/announcements:
+    https://groups.google.com/forum/#!forum/mozzi-users
+
+    Tim Barrass 2012, CC by-nc-sa.
+    T. Combriat 2020, CC by-nc-sa.
+*/
+
+#include <MozziGuts.h>
+#include <Oscil.h>
+#include <tables/cos2048_int8.h> // table for Oscils to play
+#include <mozzi_midi.h>
+#include <mozzi_fixmath.h>
+#include <EventDelay.h>
+#include <Smooth.h>
+#include <DAC_MCP49xx.h>  // https://github.com/tomcombriat/DAC_MCP49XX 
+                          // which is an adapted fork from https://github.com/exscape/electronics/tree/master/Arduino/Libraries/DAC_MCP49xx  (Thomas Backman)
+
+#define CONTROL_RATE 256 // Hz, powers of 2 are most reliable
+
+
+// Synthesis part
+Oscil<COS2048_NUM_CELLS, AUDIO_RATE> aCarrier(COS2048_DATA);
+Oscil<COS2048_NUM_CELLS, AUDIO_RATE> aModulator(COS2048_DATA);
+Oscil<COS2048_NUM_CELLS, CONTROL_RATE> kModIndex(COS2048_DATA);
+
+
+Q8n8 mod_index;
+Q16n16 deviation;
+Q16n16 carrier_freq, mod_freq;
+Q8n8 mod_to_carrier_ratio = float_to_Q8n8(3.f);
+EventDelay kNoteChangeDelay;
+
+// for note changes
+Q7n8 target_note, note0, note1, note_upper_limit, note_lower_limit, note_change_step, smoothed_note;
+Smooth <int> kSmoothNote(0.95f);
+
+
+// External audio output parameters and DAC declaration
+#define SS_PIN -1  // if you are on AVR and using PortWrite, you do not care what you put here.
+#define AUDIO_BIAS 2048  // we are at 12 bits, so we have to bias the signal of 2^(12-1) = 2048
+DAC_MCP49xx dac(DAC_MCP49xx::MCP4921, SS_PIN);
+
+
+
+void audioOutput(int l, int r)
+{
+  l += AUDIO_BIAS;
+  dac.output(l);
+}
+
+
+
+void setup() {
+  dac.init();
+
+  kNoteChangeDelay.set(768); // ms countdown, taylored to resolution of CONTROL_RATE
+  kModIndex.setFreq(.768f); // sync with kNoteChangeDelay
+  target_note = note0;
+  note_change_step = Q7n0_to_Q7n8(3);
+  note_upper_limit = Q7n0_to_Q7n8(50);
+  note_lower_limit = Q7n0_to_Q7n8(32);
+  note0 = note_lower_limit;
+  note1 = note_lower_limit + Q7n0_to_Q7n8(5);
+
+
+
+
+  dac.setPortWrite(true);  //comment this line if you do not want to use PortWrite (for non-AVR platforms)
+  startMozzi(CONTROL_RATE);
+}
+
+void setFreqs(Q8n8 midi_note) {
+  carrier_freq = Q16n16_mtof(Q8n8_to_Q16n16(midi_note)); // convert midi note to fractional frequency
+  mod_freq = ((carrier_freq >> 8) * mod_to_carrier_ratio)  ; // (Q16n16>>8)   Q8n8 = Q16n16, beware of overflow
+  deviation = ((mod_freq >> 16) * mod_index); // (Q16n16>>16)   Q8n8 = Q24n8, beware of overflow
+  aCarrier.setFreq_Q16n16(carrier_freq);
+  aModulator.setFreq_Q16n16(mod_freq);
+}
+
+void updateControl() {
+  // change note
+  if (kNoteChangeDelay.ready()) {
+    if (target_note == note0) {
+      note1 += note_change_step;
+      target_note = note1;
+    }
+    else {
+      note0 += note_change_step;
+      target_note = note0;
+    }
+
+    // change direction
+    if (note0 > note_upper_limit) note_change_step = Q7n0_to_Q7n8(-3);
+    if (note0 < note_lower_limit) note_change_step = Q7n0_to_Q7n8(3);
+
+    // reset eventdelay
+    kNoteChangeDelay.start();
+  }
+
+  // vary the modulation index
+  mod_index = (Q8n8)350 + kModIndex.next();
+
+  // here's where the smoothing happens
+  smoothed_note = kSmoothNote.next(target_note);
+  setFreqs(smoothed_note);
+
+}
+
+
+int updateAudio() {
+  Q15n16 modulation = deviation * aModulator.next() >> 8;
+
+  return (int)aCarrier.phMod(modulation) << 4;    // boost to match the 12bits output of the DAC
+                                                  // this example does not really use the full capability of the 12bits...
+}
+
+
+void loop() {
+  audioHook();
+}

--- a/examples/13.External_Audio_Output/MCP4922_mono_24bits/MCP4922_mono_24bits.ino
+++ b/examples/13.External_Audio_Output/MCP4922_mono_24bits/MCP4922_mono_24bits.ino
@@ -1,0 +1,124 @@
+/*  Example of using the two channels of a DAC to have high fidelity output using the technique described here : http://www.openmusiclabs.com/learning/digital/pwm-dac/dual-pwm-circuits/index.html
+    using Mozzi sonification library and an external dual DAC MCP4922 (original library by Thomas Backman - https://github.com/exscape/electronics/tree/master/Arduino/Libraries/DAC_MCP49xx)
+    using an user-defined audioOutput() function.
+
+
+    #define EXTERNAL_AUDIO_OUTPUT true should be uncommented in mozzi_config.h.
+
+
+    Circuit: (see the DAC library README for details)
+
+    MCP4921   //  Connect to:
+    -------       -----------
+    Vdd           V+
+    CS            any digital pin defined by SS_PIN (see after), or pin 10 on UNO / 11 on Mega if you are using Portwrite
+    SCK           SCK of Arduino
+    SDI           MOSI of Arduino
+    VoutA/B       (see after)
+    Vss           to GND
+    VrefA/B       to V+ or a clean tension ref between V+ and GND
+    LDAC          to GND
+
+
+    Dual DAC electrical connections
+    -------------------------------
+
+    VoutA -------- R1 -----------> To headphones/loudspeaker or anything else
+                            |
+    VoutB -------- R2 -------
+
+    R2 = 2^n * R1  with n the number of bits per stage.
+    This should be precise, use a trimmer on R1 to adjust it precisely.
+    Recommended values: R1 around 1k
+                        R2 around 4M
+
+    Notes: - int type in Arduino is 16 bits. So you cannot have 24 bits on an Arduino using audioOutput() function. But this does work on 32bits platforms (STM32 for instance)
+           - 24 bits is a lot. To acheive real 24 bits you need to be very careful on your electronics (good precision on R, buffer after the summing junction)   
+           - this is certainly over-kill, however this technique can prove useful for outputting 16 bits, by combining 2 * 8 bits DACs
+           - the communication with the DAC takes the same time for 8/10 and 12bits DAC, so 2*8bits should be as fast as 2*1 bits.
+    
+
+
+    Mozzi documentation/API
+    https://sensorium.github.io/Mozzi/doc/html/index.html
+
+    Mozzi help/discussion/announcements:
+    https://groups.google.com/forum/#!forum/mozzi-users
+
+    Tim Barrass 2012, CC by-nc-sa.
+    T. Combriat 2020, CC by-nc-sa.
+*/
+
+#include <MozziGuts.h>
+#include <Oscil.h>
+#include <tables/cos2048_int8.h> // table for Oscils to play
+#include <SPI.h>
+#include <DAC_MCP49xx.h>  // https://github.com/tomcombriat/DAC_MCP49XX 
+                          // which is an adapted fork from https://github.com/exscape/electronics/tree/master/Arduino/Libraries/DAC_MCP49xx  (Thomas Backman)
+
+#define CONTROL_RATE 256 // Hz, powers of 2 are most reliable
+
+
+// Synthesis part
+Oscil<COS2048_NUM_CELLS, AUDIO_RATE> aCos1(COS2048_DATA);
+Oscil<COS2048_NUM_CELLS, AUDIO_RATE> aCos2(COS2048_DATA);
+Oscil<COS2048_NUM_CELLS, CONTROL_RATE> kEnv1(COS2048_DATA);
+
+
+
+
+
+// External audio output parameters and DAC declaration
+#define SS_PIN PB6  // if you are on AVR and using PortWrite, you do not care what you put here.
+#define AUDIO_BIAS 8388608  // we are at 24 bits, so we have to bias the signal of 2^(24-1) = 8388608
+#define BITS_PER_CHANNEL 12  // each channel of the DAC is outputting 12 bits
+DAC_MCP49xx dac(DAC_MCP49xx::MCP4922, SS_PIN);
+
+
+
+void audioOutput(int l, int r)
+{
+
+  l += AUDIO_BIAS;
+
+  unsigned short lowBits = (unsigned short) l;
+  unsigned short highBits =  l >> BITS_PER_CHANNEL;
+
+  dac.output2(highBits, lowBits);  // outputs the two channels in one call.
+}
+
+
+
+void setup() {
+  aCos1.setFreq(440.f);
+  aCos2.setFreq(220.f);
+  kEnv1.setFreq(0.1f);
+
+
+  dac.init();   // start SPI communications
+
+  //dac.setPortWrite(true);  //comment this line if you do not want to use PortWrite (for non-AVR platforms)
+
+  startMozzi(CONTROL_RATE);
+}
+
+
+
+// Carry enveloppes
+int env1 = 0;
+
+void updateControl() {
+  env1 = kEnv1.next();
+}
+
+
+
+
+int updateAudio() {
+  return (aCos1.next() * aCos2.next() * env1) ; // no need to get rid of extra bits, this is already 24 bits wide.
+}
+
+
+void loop() {
+  audioHook();
+}

--- a/examples/13.External_Audio_Output/MCP4922_mono_24bits/MCP4922_mono_24bits.ino
+++ b/examples/13.External_Audio_Output/MCP4922_mono_24bits/MCP4922_mono_24bits.ino
@@ -2,6 +2,7 @@
     using Mozzi sonification library and an external dual DAC MCP4922 (original library by Thomas Backman - https://github.com/exscape/electronics/tree/master/Arduino/Libraries/DAC_MCP49xx)
     using an user-defined audioOutput() function.
 
+    WARNING: YOU CANNOT ACHEIVE MORE THAN 16BITS ON AN AVR ARDUINO, THIS EXAMPLE WON'T WORK AS IT IS.
 
     #define EXTERNAL_AUDIO_OUTPUT true should be uncommented in mozzi_config.h.
 
@@ -11,7 +12,7 @@
     MCP4921   //  Connect to:
     -------       -----------
     Vdd           V+
-    CS            any digital pin defined by SS_PIN (see after), or pin 10 on UNO / 11 on Mega if you are using Portwrite
+    CS            any digital pin defined by SS_PIN (see after), or pin 7 on UNO / 38 on Mega if you are using Portwrite
     SCK           SCK of Arduino
     SDI           MOSI of Arduino
     VoutA/B       (see after)
@@ -69,7 +70,7 @@ Oscil<COS2048_NUM_CELLS, CONTROL_RATE> kEnv1(COS2048_DATA);
 
 
 // External audio output parameters and DAC declaration
-#define SS_PIN PB6  // if you are on AVR and using PortWrite, you do not care what you put here.
+#define SS_PIN 38  // if you are on AVR and using PortWrite you need still need to put the pin you are actually using: 7 on Uno, 38 on Mega
 #define AUDIO_BIAS 8388608  // we are at 24 bits, so we have to bias the signal of 2^(24-1) = 8388608
 #define BITS_PER_CHANNEL 12  // each channel of the DAC is outputting 12 bits
 DAC_MCP49xx dac(DAC_MCP49xx::MCP4922, SS_PIN);

--- a/examples/13.External_Audio_Output/Stereo_Pan_MCP4922_stereo_12bits/Stereo_Pan_MCP4922_stereo_12bits.ino
+++ b/examples/13.External_Audio_Output/Stereo_Pan_MCP4922_stereo_12bits/Stereo_Pan_MCP4922_stereo_12bits.ino
@@ -1,0 +1,106 @@
+/*  Example of simple panning and stereo,
+    using Mozzi sonification library and an external dual DAC MCP4922 (original library by Thomas Backman - https://github.com/exscape/electronics/tree/master/Arduino/Libraries/DAC_MCP49xx)
+    using an user-defined audioOutput() function.
+
+
+    #define EXTERNAL_AUDIO_OUTPUT true should be uncommented in mozzi_config.h.
+    #define STEREO_HACK true should be set in mozzi_config.h
+
+    Circuit: (see the DAC library README for details)
+
+    MCP4921   //  Connect to:
+    -------       -----------
+    Vdd           V+
+    CS            any digital pin defined by SS_PIN (see after), or pin 10 on UNO / 11 on Mega if you are using Portwrite
+    SCK           SCK of Arduino
+    SDI           MOSI of Arduino
+    VoutA/B       to headphones/loudspeaker (right and left channels)
+    Vss           to GND
+    VrefA/B       to V+ or a clean tension ref between V+ and GND
+    LDAC          to GND
+
+
+    Mozzi documentation/API
+    https://sensorium.github.io/Mozzi/doc/html/index.html
+
+    Mozzi help/discussion/announcements:
+    https://groups.google.com/forum/#!forum/mozzi-users
+
+    Tim Barrass 2012, CC by-nc-sa.
+    T. Combriat 2020, CC by-nc-sa.
+*/
+
+#include <MozziGuts.h>
+#include <Oscil.h>
+#include <tables/cos2048_int8.h> // table for Oscils to play
+#include <SPI.h>
+#include <DAC_MCP49xx.h>  // https://github.com/tomcombriat/DAC_MCP49XX 
+                          // which is an adapted fork from https://github.com/exscape/electronics/tree/master/Arduino/Libraries/DAC_MCP49xx  (Thomas Backman)
+
+#define CONTROL_RATE 256 // Hz, powers of 2 are most reliable
+
+
+// Synthesis part
+Oscil<COS2048_NUM_CELLS, AUDIO_RATE> aCos1(COS2048_DATA);
+Oscil<COS2048_NUM_CELLS, AUDIO_RATE> aCos2(COS2048_DATA);
+Oscil<COS2048_NUM_CELLS, CONTROL_RATE> kEnv1(COS2048_DATA);
+Oscil<COS2048_NUM_CELLS, CONTROL_RATE> kEnv2(COS2048_DATA);
+
+
+
+
+// External audio output parameters and DAC declaration
+#define SS_PIN PB6  // if you are on AVR and using PortWrite, you do not care what you put here.
+#define AUDIO_BIAS 2048  // we are at 12 bits, so we have to bias the signal of 2^(12-1) = 2048
+DAC_MCP49xx dac(DAC_MCP49xx::MCP4922, SS_PIN);
+
+
+
+void audioOutput(int l, int r)
+{
+  l += AUDIO_BIAS;
+  r += AUDIO_BIAS;
+
+  dac.output2(l, r);  // outputs the two channels in one call.
+
+}
+
+
+
+void setup() {
+
+  aCos1.setFreq(440.f);
+  aCos2.setFreq(220.f);
+  kEnv1.setFreq(0.25f);
+  kEnv2.setFreq(0.4f);
+
+  dac.init();   // start SPI communications
+
+  //dac.setPortWrite(true);  //comment this line if you do not want to use PortWrite (for non-AVR platforms)
+
+  startMozzi(CONTROL_RATE);
+}
+
+
+
+// Carry enveloppes
+int env1, env2;
+
+void updateControl() {
+  env1 = kEnv1.next();
+  env2 = kEnv2.next();
+}
+
+
+// needed for stereo output
+int audio_out_1, audio_out_2;
+
+void updateAudio() {
+  audio_out_1 = (aCos1.next() * env1) >> 4 ;
+  audio_out_2 = (aCos2.next() * env2) >> 4 ;
+}
+
+
+void loop() {
+  audioHook();
+}

--- a/examples/13.External_Audio_Output/Stereo_Pan_MCP4922_stereo_12bits/Stereo_Pan_MCP4922_stereo_12bits.ino
+++ b/examples/13.External_Audio_Output/Stereo_Pan_MCP4922_stereo_12bits/Stereo_Pan_MCP4922_stereo_12bits.ino
@@ -11,7 +11,7 @@
     MCP4921   //  Connect to:
     -------       -----------
     Vdd           V+
-    CS            any digital pin defined by SS_PIN (see after), or pin 10 on UNO / 11 on Mega if you are using Portwrite
+    CS            any digital pin defined by SS_PIN (see after), or pin 7 on UNO / 38 on Mega if you are using Portwrite
     SCK           SCK of Arduino
     SDI           MOSI of Arduino
     VoutA/B       to headphones/loudspeaker (right and left channels)
@@ -50,7 +50,7 @@ Oscil<COS2048_NUM_CELLS, CONTROL_RATE> kEnv2(COS2048_DATA);
 
 
 // External audio output parameters and DAC declaration
-#define SS_PIN PB6  // if you are on AVR and using PortWrite, you do not care what you put here.
+#define SS_PIN 7  // if you are on AVR and using PortWrite you need still need to put the pin you are actually using: 7 on Uno, 38 on Mega
 #define AUDIO_BIAS 2048  // we are at 12 bits, so we have to bias the signal of 2^(12-1) = 2048
 DAC_MCP49xx dac(DAC_MCP49xx::MCP4922, SS_PIN);
 
@@ -72,11 +72,11 @@ void setup() {
   aCos1.setFreq(440.f);
   aCos2.setFreq(220.f);
   kEnv1.setFreq(0.25f);
-  kEnv2.setFreq(0.4f);
+  kEnv2.setFreq(4.f);
 
   dac.init();   // start SPI communications
 
-  //dac.setPortWrite(true);  //comment this line if you do not want to use PortWrite (for non-AVR platforms)
+  dac.setPortWrite(true);  //comment this line if you do not want to use PortWrite (for non-AVR platforms)
 
   startMozzi(CONTROL_RATE);
 }


### PR DESCRIPTION
Hi,

This provides examples for using SPI DAC MCP49XX or MCP48XX with Mozzi, using the `audioOutput` function.
Three examples are provided:
- FMsynth_MCP4921_mono_12bits is a simple mono 12 bits based on the FM example,
- Stereo_Pan_MCP4922_stereo_12bits is a simple stereo 12 bits, using Stereo_Hack,
- MCP4922_mono_24bits is a simple mono 24 bits, using the same technique than the HiFi mode of Mozzi.

#### A few notes:
- I had to modify the library I was using to provide support for non-AVR platform. The modified library is available [here](https://github.com/tomcombriat/DAC_MCP49XX) (this is written in the sketches)
- All examples work with STM32 board
- First example works fine on Arduino Mega, but the second is not so smooth. I think there is a compatibility problem between the Mega and the PortWrite technique used in the library. I would like to test on an Uno, but do not have one now. This will likely be fixed by updating the library in the future.
- Last example is impossible to get working on AVR because the audio sample does not fit the 16 bits `int` container. However, 16 bits (2*8bits) could be achieved. This works well on STM32, even if it is a bit overkill…

Let me know what you think!
Best,

Tom