### PR TITLE
Added a third template parameter to ADSR to allow long envelopes at AUDIO_RATE

### DIFF
--- a/ADSR.h
+++ b/ADSR.h
@@ -41,22 +41,22 @@ Template objects are messy when you try to use pointers to them,
 you have to include the whole template in the pointer handling.
 */
 
-template <unsigned int CONTROL_UPDATE_RATE, unsigned int LERP_RATE>
+template <unsigned int CONTROL_UPDATE_RATE, unsigned int LERP_RATE, typename T = unsigned int>
 class ADSR
 {
 private:
 
 	const unsigned int LERPS_PER_CONTROL;
 
-	unsigned int update_step_counter;
-	unsigned int num_update_steps;
+	T update_step_counter;
+	T num_update_steps;
 
 	enum {ATTACK,DECAY,SUSTAIN,RELEASE,IDLE};
 
 
 	struct phase{
 		byte phase_type;
-		unsigned int update_steps;
+		T update_steps;
 		long lerp_steps; // signed, to match params to transition (line) type Q15n16, below
 		Q8n0 level;
 	}attack,decay,sustain,release,idle;
@@ -68,8 +68,8 @@ private:
 	Line <Q15n16> transition; // scale up unsigned char levels for better accuracy, then scale down again for output
 
 	inline
-	unsigned int convertMsecToControlUpdateSteps(unsigned int msec){
-		return (uint16_t) (((uint32_t)msec*CONTROL_UPDATE_RATE)>>10); // approximate /1000 with shift
+	T convertMsecToControlUpdateSteps(unsigned int msec){
+		return (T) (((uint32_t)msec*CONTROL_UPDATE_RATE)>>10); // approximate /1000 with shift
 	}
 
 

--- a/examples/07.Envelopes/ADSR_Audio_Rate_Envelope_Long/ADSR_Audio_Rate_Envelope_Long.ino
+++ b/examples/07.Envelopes/ADSR_Audio_Rate_Envelope_Long/ADSR_Audio_Rate_Envelope_Long.ino
@@ -1,0 +1,112 @@
+/*  Example applying an ADSR envelope to an audio signal
+    with Mozzi sonification library.  This is nearly an exact copy of 
+    ADSR_Audio_Rate_Envelope which shows
+    how to use an ADSR which updates at AUDIO_RATE, in updateAudio(),
+    output using next() at AUDIO_RATE in updateAudio(). This one uses 
+    unsigned long as the third ADSR parameter to allow long envelopes
+    to be updated at AUDIO_RATE.
+
+    Another example in this folder shows an ADSR updating at CONTROL_RATE,
+    which is more efficient, but AUDIO_RATE updates shown in this example
+    enable faster envelope transitions.
+
+    Demonstrates a simple ADSR object being controlled with
+    noteOn() and noteOff() instructions.
+
+    Mozzi documentation/API
+    https://sensorium.github.io/Mozzi/doc/html/index.html
+
+    Mozzi help/discussion/announcements:
+    https://groups.google.com/forum/#!forum/mozzi-users
+
+    Tim Barrass 2013, CC by-nc-sa.
+*/
+
+#include <MozziGuts.h>
+#include <Oscil.h>
+#include <EventDelay.h>
+#include <ADSR.h>
+#include <tables/sin8192_int8.h>
+#include <mozzi_rand.h>
+#include <mozzi_midi.h>
+
+Oscil <8192, AUDIO_RATE> aOscil(SIN8192_DATA);;
+
+// for triggering the envelope
+EventDelay noteDelay;
+
+ADSR <AUDIO_RATE, AUDIO_RATE, unsigned long> envelope;
+
+boolean note_is_on = true;
+
+void setup(){
+  //Serial.begin(9600); // for Teensy 3.1, beware printout can cause glitches
+  Serial.begin(115200);
+  randSeed(); // fresh random
+  noteDelay.set(20000); // 2 second countdown
+  startMozzi();
+}
+
+
+unsigned int duration, attack, decay, sustain, release_ms;
+
+void updateControl(){
+  if(noteDelay.ready()){
+
+      // choose envelope levels
+      byte attack_level = rand(1024)+127;
+      byte decay_level = rand(2048);
+      envelope.setADLevels(attack_level,decay_level);
+
+    // generate a random new adsr time parameter value in milliseconds
+     unsigned int new_value = rand(3000) +100;
+     Serial.println(new_value);
+     // randomly choose one of the adsr parameters and set the new value
+     switch (rand(4)){
+       case 0:
+       attack = new_value;
+       break;
+
+       case 1:
+       decay = new_value;
+       break;
+
+       case 2:
+       sustain = new_value;
+       break;
+
+       case 3:
+       release_ms = new_value;
+       break;
+     }
+     envelope.setTimes(attack,decay,sustain,release_ms);
+     envelope.noteOn();
+
+     byte midi_note = rand(107)+20;
+     aOscil.setFreq((int)mtof(midi_note));
+
+/*
+     // print to screen
+     Serial.print("midi_note\t"); Serial.println(midi_note);
+     Serial.print("attack_level\t"); Serial.println(attack_level);
+     Serial.print("decay_level\t"); Serial.println(decay_level);
+     Serial.print("attack\t\t"); Serial.println(attack);
+     Serial.print("decay\t\t"); Serial.println(decay);
+     Serial.print("sustain\t\t"); Serial.println(sustain);
+     Serial.print("release\t\t"); Serial.println(release_ms);
+     Serial.println();
+*/
+     noteDelay.start(attack+decay+sustain+release_ms);
+   }
+}
+
+
+int updateAudio(){
+  envelope.update();
+  return (int) (envelope.next() * aOscil.next())>>8;
+}
+
+
+void loop(){
+  audioHook(); // required here
+}


### PR DESCRIPTION
Hi!

This adds a third template parameter to the ADSR, affecting the update steps.

It allows to create long envelopes at AUDIO_RATE as the `unsigned int` initially used can be replaced by `unsigned long` for instance; the initial implementation does not allow ADSR longer than 3.6s (if my memory is correct) at AUDIO_RATE. This reduces performances on AVR, but does not affect native 32bits platforms like STM32 or ESP.

A default parameter (`unsigned int`) is specified thus, this does not change the behavior of existing sketches.

An example, basically copy pasted from an existing one, with small adaptations is also added.

Let me know if you have any comments!

Best,

