### PR TITLE
ESP32 support (internal and PT8211 DAC)

### DIFF
--- a/AudioConfigESP32.h
+++ b/AudioConfigESP32.h
@@ -15,4 +15,12 @@
 
 #define AUDIO_BIAS ((uint16_t) 1<<(7))
 
+// Audio output options
+#define INTERNAL_DAC 1 // BUGGY !!! ESP32 internal DAC via I2S, requires AUDIO_RATE 32768, output on pin 26
+#define PT8211_DAC 2 // ESP32 with PT8211 DAC via I2S, requires AUDIO_RATE 32768
+
+// Set output mode
+#define ESP32_AUDIO_OUT_MODE PT8211_DAC
+
+
 #endif        //  #ifndef AUDIOCONFIGESP_H

--- a/AudioConfigESP32.h
+++ b/AudioConfigESP32.h
@@ -1,0 +1,18 @@
+#ifndef AUDIOCONFIGESP32_H
+#define AUDIOCONFIGESP32_H
+
+#if not IS_ESP32()
+#error This header should be included for ESP32 architecture, only
+#endif
+
+#if (AUDIO_MODE == HIFI)
+#error HIFI mode is not available for this CPU architecture (but check ESP32_AUDIO_OUT_MODE, and PDM_RESOLUTION)
+#endif
+
+#if (STEREO_HACK == true)
+#error Stereo is not available for this CPU
+#endif
+
+#define AUDIO_BIAS ((uint16_t) 1<<(7))
+
+#endif        //  #ifndef AUDIOCONFIGESP_H

--- a/MozziGuts.cpp
+++ b/MozziGuts.cpp
@@ -37,7 +37,6 @@
 #elif IS_ESP8266()
 #include <Ticker.h>
 #include <uart.h>
-#elif IS_ESP32()
 #endif
 
 
@@ -101,7 +100,7 @@ CircularBuffer<unsigned int> output_buffer2; // fixed size 256
 	#include "freertos/queue.h"	
 	hw_timer_t * timer = NULL;
 	int i2s_num = 0;
-#if (ESP32_PT8211 == true)	
+#if (ESP32_AUDIO_OUT_MODE == PT8211_DAC)	
 	i2s_config_t i2s_config = {
 		.mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_TX),
 		.sample_rate = AUDIO_RATE,
@@ -119,7 +118,7 @@ CircularBuffer<unsigned int> output_buffer2; // fixed size 256
 	  .data_out_num = 33, 
 	  .data_in_num = -1 
 	};
-#elif (ESP32_internal == true)
+#elif (ESP32_AUDIO_OUT_MODE == INTERNAL_DAC)
 	i2s_config_t i2s_config = {
 		.mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_TX | I2S_MODE_DAC_BUILT_IN),
 		.sample_rate = AUDIO_RATE,
@@ -500,9 +499,9 @@ void samd21AudioOutput() {
 
 #elif IS_ESP32()
 static void IRAM_ATTR esp32AudioOutput() {
-#if (ESP32_PT8211 == true)	
+#if (ESP32_AUDIO_OUT_MODE == PT8211_DAC)	
 	uint32_t outputEsp32=(uint32_t)output_buffer.read();
-#elif (ESP32_internal == true)
+#elif (ESP32_AUDIO_OUT_MODE == INTERNAL_DAC)
 	uint32_t outputEsp32=(uint32_t)output_buffer.read()<<8;
 #endif
 	i2s_write_bytes((i2s_port_t)i2s_num, (const char *)&outputEsp32, sizeof(uint32_t), 0);
@@ -559,14 +558,14 @@ static void startAudioStandard() {
 #elif IS_ESP32()
   #ifdef DO_NOT_INIT_ESP32_I2S
   #else
-	#if (ESP32_PT8211 == true)
+	#if (ESP32_AUDIO_OUT_MODE == PT8211_DAC)
 	i2s_driver_install((i2s_port_t)i2s_num, &i2s_config, 0, NULL);
 	i2s_set_pin((i2s_port_t)i2s_num, &pin_config);
 	//i2s_set_sample_rates((i2s_port_t)i2s_num, 44100);
 	i2s_set_sample_rates((i2s_port_t)i2s_num, AUDIO_RATE);    	
 	i2s_zero_dma_buffer((i2s_port_t)i2s_num);
 	
-	#elif (ESP32_internal == true)
+	#elif (ESP32_AUDIO_OUT_MODE == INTERNAL_DAC)
 	i2s_driver_install((i2s_port_t)i2s_num, &i2s_config, 0, NULL); 
 	i2s_set_pin((i2s_port_t)i2s_num, NULL);
 	i2s_set_sample_rates((i2s_port_t)i2s_num, AUDIO_RATE);

--- a/MozziGuts.h
+++ b/MozziGuts.h
@@ -180,6 +180,8 @@ HIFI is not available/not required on Teensy 3.* or ARM.
 #include "AudioConfigSTM32.h"
 #elif IS_ESP8266()
 #include "AudioConfigESP.h"
+#elif IS_ESP32()
+#include "AudioConfigESP32.h"
 #elif IS_SAMD21()
 #include "AudioConfigSAMD21.h"
 #elif IS_AVR()

--- a/hardware_defines.h
+++ b/hardware_defines.h
@@ -17,8 +17,9 @@
 #define IS_TEENSY3() (defined(__MK20DX128__) || defined(__MK20DX256__) || defined(__MK64FX512__) || defined(__MK66FX1M0__) || defined(__MKL26Z64__) )  // 32bit arm-based Teensy
 #define IS_STM32() (defined(__arm__) && !IS_TEENSY3() && !IS_SAMD21())  // STM32 boards (note that only the maple based core is supported at this time. If another cores is to be supported in the future, this define should be split.
 #define IS_ESP8266() (defined(ESP8266))
+#define IS_ESP32() (defined(ESP32))
 
-#if !(IS_AVR() || IS_TEENSY3() || IS_STM32() || IS_ESP8266() || IS_SAMD21())
+#if !(IS_AVR() || IS_TEENSY3() || IS_STM32() || IS_ESP8266() || IS_SAMD21() || IS_ESP32())
 #error Your hardware is not supported by Mozzi or not recognized. Edit hardware_defines.h to proceed.
 #endif
 

--- a/mozzi_analog.cpp
+++ b/mozzi_analog.cpp
@@ -227,7 +227,7 @@ void adcReadSelectedChannels() {
 
 
 int mozziAnalogRead(uint8_t pin) {
-#if IS_ESP8266()
+#if IS_ESP8266() || IS_ESP32()
 #warning Asynchronouos analog reads not implemented for this platform
 	return analogRead(pin);
 #else

--- a/mozzi_config.h
+++ b/mozzi_config.h
@@ -91,10 +91,10 @@ You need to have \#define STEREO_HACK true in mozzi_config.h
 
 //#define EXTERNAL_AUDIO_OUTPUT true
 
-// ESP32 with PT8211 DAC, requires AUDIO_RATE 32768, output on pin 26
+// ESP32 with PT8211 DAC, requires AUDIO_RATE 32768
 #define ESP32_PT8211 true
 
-// ESP32 internal DAC, requires AUDIO_RATE 32768, 
+// ESP32 internal DAC, requires AUDIO_RATE 32768, output on pin 26 
 // BUGGY !!!
 //#define ESP32_internal true
 

--- a/mozzi_config.h
+++ b/mozzi_config.h
@@ -58,8 +58,8 @@ and comment out \#define AUDIO_MODE STANDARD and \#define AUDIO_MODE STANDARD_PL
 http://blog.makezine.com/2008/05/29/makeit-protodac-shield-fo/ .
 Mozzi-users list has a thread on this.
 */
-#define AUDIO_RATE 16384
-//#define AUDIO_RATE 32768
+//#define AUDIO_RATE 16384
+#define AUDIO_RATE 32768
 //#define AUDIO_RATE 65536 // try on Teensy3/3.1
 
 
@@ -91,5 +91,11 @@ You need to have \#define STEREO_HACK true in mozzi_config.h
 
 //#define EXTERNAL_AUDIO_OUTPUT true
 
+// ESP32 with PT8211 DAC, requires AUDIO_RATE 32768, output on pin 26
+#define ESP32_PT8211 true
+
+// ESP32 internal DAC, requires AUDIO_RATE 32768, 
+// BUGGY !!!
+//#define ESP32_internal true
 
 #endif        //  #ifndef MOZZI_CONFIG_H

--- a/mozzi_config.h
+++ b/mozzi_config.h
@@ -58,8 +58,8 @@ and comment out \#define AUDIO_MODE STANDARD and \#define AUDIO_MODE STANDARD_PL
 http://blog.makezine.com/2008/05/29/makeit-protodac-shield-fo/ .
 Mozzi-users list has a thread on this.
 */
-//#define AUDIO_RATE 16384
-#define AUDIO_RATE 32768
+#define AUDIO_RATE 16384
+//#define AUDIO_RATE 32768
 //#define AUDIO_RATE 65536 // try on Teensy3/3.1
 
 

--- a/mozzi_pgmspace.h
+++ b/mozzi_pgmspace.h
@@ -6,7 +6,7 @@
 
 #include "hardware_defines.h"
 
-#if IS_ESP8266()
+#if IS_ESP8266() || IS_ESP32()
 template<typename T> inline T FLASH_OR_RAM_READ(T* address) {
     return (T) (*address);
 }


### PR DESCRIPTION
Optional choices for PT8211 DAC and internal DAC in mozzi_config.h, though internal DAC is buggy. 

I have a working solution for internal DAC based on the Mozzi version from around january 2020, because that's what zcarlos's solution in the google forum was built on. I fixed that to work better. However when I port those I2S settings to the current version of Mozzi I get a chopped up signal that I can't get into shape by bitshifting ranges, which helped before.  

PT8211 works, though I am unsure whether timing of sample calculation and output to the DAC are properly synced.

I checked whether an Arduino Duemilanove still works. Seems fine. 