### PR TITLE
Use higher audio rate by default on faster boards

### DIFF
--- a/hardware_defines.h
+++ b/hardware_defines.h
@@ -29,4 +29,10 @@
 #define NUM_ANALOG_INPUTS 1
 #endif
 
+#if IS_AVR()
+#define AUDIO_RATE_PLATFORM_DEFAULT 16384
+#else
+#define AUDIO_RATE_PLATFORM_DEFAULT 32768
+#endif
+
 #endif /* HARDWARE_DEFINES_H_ */

--- a/mozzi_config.h
+++ b/mozzi_config.h
@@ -1,5 +1,6 @@
 #ifndef MOZZI_CONFIG_H
 #define MOZZI_CONFIG_H
+#include "hardware_defines.h"
 
 /*
 Edit this file if you want to choose your own configuration options.
@@ -58,9 +59,10 @@ and comment out \#define AUDIO_MODE STANDARD and \#define AUDIO_MODE STANDARD_PL
 http://blog.makezine.com/2008/05/29/makeit-protodac-shield-fo/ .
 Mozzi-users list has a thread on this.
 */
-#define AUDIO_RATE 16384
-//#define AUDIO_RATE 32768
-//#define AUDIO_RATE 65536 // try on Teensy3/3.1
+#define AUDIO_RATE AUDIO_RATE_PLATFORM_DEFAULT
+//#define AUDIO_RATE 16384 // default on AVR / classic Arduino
+//#define AUDIO_RATE 32768 // default on most other platforms
+//#define AUDIO_RATE 65536 // try on Teensy3/3.1 or other strong cpus
 
 
 /** @ingroup core


### PR DESCRIPTION
AUDIO_RATE 16384 is a sensible default for the classic Arduino boards, but for the newly added platforms (Teensy3, Arduino Due, STM32, ESP8266, soon ESP32), that does not seem to make a lot of sense.

This PR simply ups that to 32768 on these platforms, while leaving AVR unchanged. With this, there should be a little less need to customize mozzi_config.h with. The PR might affect sketches that are already pushing the stronger boards to the limits, but I think that risk is mostly theoretical.

One point for discussion could might be, whether it would make sense to go even higher, though. Thoughts?