### PR TITLE
Remove unused phase in ADSR

### DIFF
--- a/ADSR.h
+++ b/ADSR.h
@@ -131,19 +131,25 @@ public:
 		*/
 	void update(){ // control rate
 
-		switch(current_phase->phase_type) {
+        switch(current_phase->phase_type) {
 
 		case ATTACK:
-			checkForAndSetNextPhase(&decay);
-			break;
+			if (decay.lerp_steps > 0) {
+				checkForAndSetNextPhase(&decay);
+				break;
+			}
 
 		case DECAY:
-			checkForAndSetNextPhase(&sustain);
-			break;
+			if (sustain.lerp_steps > 0) {
+				checkForAndSetNextPhase(&sustain);
+				break;
+			}
 
 		case SUSTAIN:
-			checkForAndSetNextPhase(&release);
-			break;
+			if (release.lerp_steps > 0) {
+				checkForAndSetNextPhase(&release);
+				break;
+			}
 
 		case RELEASE:
 			checkForAndSetNextPhase(&idle);
@@ -152,7 +158,7 @@ public:
 		case IDLE:
 			adsr_playing = false;
 			break;
-		}
+        }
 	}
 
 
@@ -180,6 +186,16 @@ public:
 	void noteOn(bool reset=false){
 		if (reset) transition.set(0);
 		setPhase(&attack);
+		if (attack.lerp_steps == 0) {
+            if (decay.lerp_steps > 0)
+                setPhase(&decay);
+            else if (sustain.lerp_steps > 0)
+                setPhase(&sustain);
+            else if (release.lerp_steps > 0)
+                setPhase(&release);
+            else
+                setPhase(&idle);
+        }
 		adsr_playing = true;
 	}
 


### PR DESCRIPTION
Here is a small improvement on ADSR envelope to remove noize from unused phase. Following is an example to understand the improvement:

```ino

#include <MozziGuts.h>
#include <ADSR.h>
#include <Oscil.h>
#include <tables/triangle_dist_squared_2048_int8.h>

// this should be after MozziGuts
#include <EventDelay.h>

byte gSeqBPM = 80;
unsigned int gTempo = 1000 / ((gSeqBPM * 4) / 60);
byte delayBetweenNote = 3 * gTempo;

byte envelopeValue2;

// oscillators
Oscil<TRIANGLE_DIST_SQUARED_2048_NUM_CELLS, AUDIO_RATE> aOscil(
    TRIANGLE_DIST_SQUARED_2048_DATA);

// envelopes
ADSR<CONTROL_RATE, AUDIO_RATE> envelope1;
ADSR<CONTROL_RATE, AUDIO_RATE> envelope2;

int frequency = 45;

EventDelay noteDelay;
void updateControl() {
    if (noteDelay.ready()) {
        aOscil.setFreq(frequency);
        envelope1.noteOn();
        envelope2.noteOn();
        noteDelay.start(gTempo + delayBetweenNote);
    }
    envelope1.update();
    envelope2.update();
}

int updateAudio() {
    int freq = frequency + (envelope2.next() >> 1);
    aOscil.setFreq(freq);
    return (int)((envelope1.next() * aOscil.next()) >> 1) >> 8;
}

void loop() { audioHook(); }

byte PeakLevel = 200;
byte SubstainLevel = 150;
void setup() {
    envelope1.setLevels(PeakLevel, SubstainLevel, SubstainLevel, 0);
    envelope1.setTimes(gTempo * 0 / 100, gTempo * 0 / 100, gTempo * 0 / 100,
                       gTempo * 100 / 100);

    envelope2.setLevels(200, 200, 200, 0);
    envelope2.setTimes(gTempo * 30 / 100, gTempo * 0 / 100, gTempo * 40 / 100,
                       gTempo * 30 / 100);

    startMozzi();
}
```
On each beat, without this fix, we hear a little noise due to some delay on the phases. If we apply the fix, the noize is removed.