### PR TITLE
Changed comments suggesting the pitch being encoded as frequency

### DIFF
--- a/PDResonant.h
+++ b/PDResonant.h
@@ -48,7 +48,7 @@ public:
 
 	/**  Play a note in response to midi input.  Params copied from MIDI library HandleNoteOn().
 	@param channel is the midi channel
-	@param pitch is the frequency in Hz
+	@param pitch is the midi note
 	@param velocity you know what it is
 	*/
 	void noteOn(byte channel, byte pitch, byte velocity)
@@ -63,7 +63,7 @@ public:
 
 	/**  Stop a note in response to midi input.    Params copied from MIDI library HandleNoteOff()
 	@param channel is the midi channel
-	@param pitch is the frequency in Hz
+	@param pitch is the midi note
 	@param velocity you know what it is
 	*/
 	void noteOff(byte channel, byte pitch, byte velocity)


### PR DESCRIPTION
Hi,
Reading the doc, I was surprised that it was written there that the PDresonant filter was receiving the frequency of the note as parameter, encoded in `byte`. If I am correct, it actually expect the midi note value.

Not a big change, but can maybe remove some confusion.

Best,
Tom