### PR TITLE
Fix compilation for Teensy3

### DIFF
--- a/MozziGuts.cpp
+++ b/MozziGuts.cpp
@@ -396,8 +396,8 @@ void samd21AudioOutput() {
 static void startAudioStandard() {
 
 #if IS_TEENSY3()
-  adc->setAveraging(0);
-  adc->setConversionSpeed(
+  adc->adc0->setAveraging(0);
+  adc->adc0->setConversionSpeed(
       ADC_CONVERSION_SPEED::MED_SPEED); // could be HIGH_SPEED, noisier
 
   analogWriteResolution(12);

--- a/MozziGuts.cpp
+++ b/MozziGuts.cpp
@@ -399,9 +399,8 @@ static void startAudioStandard() {
   adc->adc0->setAveraging(0);
   adc->adc0->setConversionSpeed(
       ADC_CONVERSION_SPEED::MED_SPEED); // could be HIGH_SPEED, noisier
-
   analogWriteResolution(12);
-  timer1.begin(defaultAudioOutput, 1000000UL / AUDIO_RATE);
+  timer1.begin(defaultAudioOutput, 1000000. / AUDIO_RATE);
 #elif IS_SAMD21()
 #ifdef ARDUINO_SAMD_CIRCUITPLAYGROUND_EXPRESS
   {

--- a/mozzi_analog.cpp
+++ b/mozzi_analog.cpp
@@ -71,7 +71,7 @@ void adcEnableInterrupt(){
 void setupMozziADC(int8_t speed) {
 #if IS_TEENSY3()
 	adc = new ADC();
-	adc->enableInterrupts(ADC_0);
+	adc->adc0->enableInterrupts(ADC_0);
 #elif IS_STM32()
 	adc.calibrate();
 	setupFastAnalogRead(speed);


### PR DESCRIPTION
Mozzi would not compile with the new TeensyDuino (probably since the arrival of Teensy4). This is caused by a small change in the Teensy API regarding ADC.

This PR fix the problem and allow to use Mozzi on Teensy 3X with the newer Teensyduino.
Note that this will probably won't compile for people still using the old Teensyduino. In that case a simple update of Teensyduino solves the problem.