### PR TITLE
FIX `fromAlmostNBits` for 32 bitters

### DIFF
--- a/AudioOutput.h
+++ b/AudioOutput.h
@@ -111,10 +111,6 @@ struct StereoOutput {
   /** @see MonoOutput::from16Bit(), stereo variant */
   static inline StereoOutput from16Bit(int16_t l, int16_t r) { return fromNBit(16, l, r); }
   /** @see MonoOutput::fromAlmostNBit(), stereo variant */
-  //static inline StereoOutput fromAlmostNBit(uint8_t bits, int16_t l, int16_t r) { return StereoOutput(SCALE_AUDIO_NEAR(l, bits), SCALE_AUDIO_NEAR(r, bits)); }
-  
-  /** @see MonoOutput::fromAlmostNBit(), stereo variant, 32 bit overload */
-  //static inline StereoOutput fromAlmostNBit(uint8_t bits, int32_t l, int32_t r) { return StereoOutput(SCALE_AUDIO_NEAR(l, bits), SCALE_AUDIO_NEAR(r, bits)); }
   template<typename A, typename B> static inline StereoOutput fromAlmostNBit(A bits, B l, B r) { return StereoOutput(SCALE_AUDIO_NEAR(l, bits), SCALE_AUDIO_NEAR(r, bits)); }
 private:
   AudioOutputStorage_t _l;
@@ -172,9 +168,6 @@ struct MonoOutput {
    *
    *  @example fromAlmostNBit(10, oscilA.next() + oscilB.next() + oscilC.next());
    */
-  //static inline MonoOutput fromAlmostNBit(uint8_t bits, int16_t l) { return MonoOutput(SCALE_AUDIO_NEAR(l, bits)); }
-  /** 32bit overload. See above. */
-  //static inline MonoOutput fromAlmostNBit(uint8_t bits, int32_t l) { return MonoOutput(SCALE_AUDIO_NEAR(l, bits)); }
   template<typename A, typename B> static inline MonoOutput fromAlmostNBit(A bits, B l) { return MonoOutput(SCALE_AUDIO_NEAR(l, bits)); }
 
 private:

--- a/AudioOutput.h
+++ b/AudioOutput.h
@@ -111,9 +111,11 @@ struct StereoOutput {
   /** @see MonoOutput::from16Bit(), stereo variant */
   static inline StereoOutput from16Bit(int16_t l, int16_t r) { return fromNBit(16, l, r); }
   /** @see MonoOutput::fromAlmostNBit(), stereo variant */
-  static inline StereoOutput fromAlmostNBit(uint8_t bits, int16_t l, int16_t r) { return StereoOutput(SCALE_AUDIO_NEAR(l, bits), SCALE_AUDIO_NEAR(r, bits)); }
+  //static inline StereoOutput fromAlmostNBit(uint8_t bits, int16_t l, int16_t r) { return StereoOutput(SCALE_AUDIO_NEAR(l, bits), SCALE_AUDIO_NEAR(r, bits)); }
+  
   /** @see MonoOutput::fromAlmostNBit(), stereo variant, 32 bit overload */
-  static inline StereoOutput fromAlmostNBit(uint8_t bits, int32_t l, int32_t r) { return StereoOutput(SCALE_AUDIO_NEAR(l, bits), SCALE_AUDIO_NEAR(r, bits)); }
+  //static inline StereoOutput fromAlmostNBit(uint8_t bits, int32_t l, int32_t r) { return StereoOutput(SCALE_AUDIO_NEAR(l, bits), SCALE_AUDIO_NEAR(r, bits)); }
+  template<typename A, typename B> static inline StereoOutput fromAlmostNBit(A bits, B l, B r) { return StereoOutput(SCALE_AUDIO_NEAR(l, bits), SCALE_AUDIO_NEAR(r, bits)); }
 private:
   AudioOutputStorage_t _l;
   AudioOutputStorage_t _r;
@@ -170,9 +172,11 @@ struct MonoOutput {
    *
    *  @example fromAlmostNBit(10, oscilA.next() + oscilB.next() + oscilC.next());
    */
-  static inline MonoOutput fromAlmostNBit(uint8_t bits, int16_t l) { return MonoOutput(SCALE_AUDIO_NEAR(l, bits)); }
+  //static inline MonoOutput fromAlmostNBit(uint8_t bits, int16_t l) { return MonoOutput(SCALE_AUDIO_NEAR(l, bits)); }
   /** 32bit overload. See above. */
-  static inline MonoOutput fromAlmostNBit(uint8_t bits, int32_t l) { return MonoOutput(SCALE_AUDIO_NEAR(l, bits)); }
+  //static inline MonoOutput fromAlmostNBit(uint8_t bits, int32_t l) { return MonoOutput(SCALE_AUDIO_NEAR(l, bits)); }
+  template<typename A, typename B> static inline MonoOutput fromAlmostNBit(A bits, B l) { return MonoOutput(SCALE_AUDIO_NEAR(l, bits)); }
+
 private:
   AudioOutputStorage_t _l;
 };

--- a/examples/10.Audio_Filters/LowPassFilterX2/LowPassFilterX2.ino
+++ b/examples/10.Audio_Filters/LowPassFilterX2/LowPassFilterX2.ino
@@ -54,7 +54,7 @@ void updateControl(){
 
 
 AudioOutput_t updateAudio(){
-  return MonoOutput::fromAlmostNBit(9, (((char)lpf1.next(aCrunchySound1.next()))>>1) + (char)lpf2.next(aCrunchySound2.next());
+  return MonoOutput::fromAlmostNBit(9, (((char)lpf1.next(aCrunchySound1.next()))>>1) + (char)lpf2.next(aCrunchySound2.next()));
 }
 
 

--- a/examples/12.Misc/Stereo_Hack_Pan/Stereo_Hack_Pan.ino
+++ b/examples/12.Misc/Stereo_Hack_Pan/Stereo_Hack_Pan.ino
@@ -51,7 +51,7 @@ void updateControl()
 
 AudioOutput_t updateAudio() {
   int asig = aNoise.next();
-  return StereoOutput::stereoFrom16Bit(asig*ampA, asig*ampB);
+  return StereoOutput::from16Bit(asig*ampA, asig*ampB);
 }
 
 


### PR DESCRIPTION
Alongside two non-compiling examples.

Should solve #140 .

Will test now.