### PR TITLE
Fix compilation for STM32_arduino newest version

### DIFF
--- a/MozziGuts_impl_STM32.hpp
+++ b/MozziGuts_impl_STM32.hpp
@@ -46,7 +46,7 @@ void setupFastAnalogRead(int8_t speed) {
 }
 
 void setupMozziADC(int8_t speed) {
-  adc.attachInterrupt(stm32_adc_eoc_handler, ADC_EOC);
+  adc.attachInterrupt(stm32_adc_eoc_handler);
 }
 
 ////// END analog input code ////////


### PR DESCRIPTION
After reinstalling Arduino_STM32 to the latest version after a complete reinstallation of my computer, I could not compile Mozzi for STM32. Apparently, the function to attach the ADC interrupt changed. This fixes the compilation here (but I think this would need confirmation from @tfry-git ).

Best,