### PR TITLE
Fix compilation for Teensys

### DIFF
--- a/AudioOutput.h
+++ b/AudioOutput.h
@@ -106,6 +106,8 @@ struct StereoOutput {
   static inline StereoOutput fromNBit(uint8_t bits, int16_t l, int16_t r) { return StereoOutput(SCALE_AUDIO(l, bits), SCALE_AUDIO(r, bits)); }
   /** @see MonoOutput::fromNBit(), stereo variant, 32 bit overload */
   static inline StereoOutput fromNBit(uint8_t bits, int32_t l, int32_t r) { return StereoOutput(SCALE_AUDIO(l, bits), SCALE_AUDIO(r, bits)); }
+  /** @see MonoOutput::fromNBit(), stereo variant, native int bit overload */
+  static inline StereoOutput fromNBit(uint8_t bits, int l, int r) { return StereoOutput(SCALE_AUDIO(l, bits), SCALE_AUDIO(r, bits)); }  
   /** @see MonoOutput::from8Bit(), stereo variant */
   static inline StereoOutput from8Bit(int16_t l, int16_t r) { return fromNBit(8, l, r); }
   /** @see MonoOutput::from16Bit(), stereo variant */
@@ -155,6 +157,8 @@ struct MonoOutput {
   static inline MonoOutput fromNBit(uint8_t bits, int16_t l) { return MonoOutput(SCALE_AUDIO(l, bits)); }
   /** 32bit overload. See above. */
   static inline MonoOutput fromNBit(uint8_t bits, int32_t l) { return MonoOutput(SCALE_AUDIO(l, bits)); }
+  /** Native int overload. Fixes Compilation on Teensys. */
+  static inline MonoOutput fromNBit(uint8_t bits, int l) { return MonoOutput(SCALE_AUDIO(l, bits)); }
   /** Construct an audio frame from a zero-centered value known to be in the 8 bit range. On AVR, STANDADR or STANDARD_PLUS mode, this is effectively the same as calling the
    * constructor, directly (no scaling gets applied). On platforms/configs using more bits, an appropriate left-shift will be performed. */
   static inline MonoOutput from8Bit(int16_t l) { return fromNBit(8, l); }

--- a/AudioOutput.h
+++ b/AudioOutput.h
@@ -103,11 +103,7 @@ struct StereoOutput {
   StereoOutput& clip() { _l = CLIP_AUDIO(_l); _r = CLIP_AUDIO(_r); return *this; };
 
   /** @see MonoOutput::fromNBit(), stereo variant */
-  static inline StereoOutput fromNBit(uint8_t bits, int16_t l, int16_t r) { return StereoOutput(SCALE_AUDIO(l, bits), SCALE_AUDIO(r, bits)); }
-  /** @see MonoOutput::fromNBit(), stereo variant, 32 bit overload */
-  static inline StereoOutput fromNBit(uint8_t bits, int32_t l, int32_t r) { return StereoOutput(SCALE_AUDIO(l, bits), SCALE_AUDIO(r, bits)); }
-  /** @see MonoOutput::fromNBit(), stereo variant, native int bit overload */
-  static inline StereoOutput fromNBit(uint8_t bits, int l, int r) { return StereoOutput(SCALE_AUDIO(l, bits), SCALE_AUDIO(r, bits)); }  
+template<typename T> static inline StereoOutput fromNBit(uint8_t bits, T l, T r) { return StereoOutput(SCALE_AUDIO(l, bits), SCALE_AUDIO(r, bits)); }
   /** @see MonoOutput::from8Bit(), stereo variant */
   static inline StereoOutput from8Bit(int16_t l, int16_t r) { return fromNBit(8, l, r); }
   /** @see MonoOutput::from16Bit(), stereo variant */
@@ -154,11 +150,7 @@ struct MonoOutput {
   /** Construct an audio frame a zero-centered value known to be in the N bit range. Appropriate left- or right-shifting will be performed, based on the number of output
    *  bits available. While this function takes care of the shifting, beware of potential overflow issues, if your intermediary results exceed the 16 bit range. Use proper
    *  casts to int32_t or larger in that case (and the compiler will automatically pick the 32 bit overload in this case) */
-  static inline MonoOutput fromNBit(uint8_t bits, int16_t l) { return MonoOutput(SCALE_AUDIO(l, bits)); }
-  /** 32bit overload. See above. */
-  static inline MonoOutput fromNBit(uint8_t bits, int32_t l) { return MonoOutput(SCALE_AUDIO(l, bits)); }
-  /** Native int overload. Fixes Compilation on Teensys. */
-  static inline MonoOutput fromNBit(uint8_t bits, int l) { return MonoOutput(SCALE_AUDIO(l, bits)); }
+  template<typename T> static inline MonoOutput fromNBit(uint8_t bits, T l) { return MonoOutput(SCALE_AUDIO(l, bits)); }
   /** Construct an audio frame from a zero-centered value known to be in the 8 bit range. On AVR, STANDADR or STANDARD_PLUS mode, this is effectively the same as calling the
    * constructor, directly (no scaling gets applied). On platforms/configs using more bits, an appropriate left-shift will be performed. */
   static inline MonoOutput from8Bit(int16_t l) { return fromNBit(8, l); }

--- a/examples/12.Misc/Stereo_Hack/Stereo_Hack.ino
+++ b/examples/12.Misc/Stereo_Hack/Stereo_Hack.ino
@@ -40,7 +40,7 @@ void updateControl(){
 
 AudioOutput_t updateAudio(){
   int asig = aNoise.next();
-  return StereoOutput::fromNBit(24, (long)pan*asig, ((long)65535-pan)*asig);
+  return StereoOutput::fromNBit(24, (long)pan*asig, (long)(65535-pan)*asig);
 }
 
 


### PR DESCRIPTION
As said in #159 , Teensy would not compile on `static inline MonoOutput fromNBit` if the sample type is a plain `int` (which is actually the default audio type).

This fixes this problem but I'll wait for a go from @tfry-git to merge this one as I am not sure that multiplying the overloads is actually the good solution.

As for now (without this PR), the example in #159 does not compile on 32bits platforms, but works on AVR.

Best,
Tom