### PR TITLE
Added I2S (native) output support for RP2040

### DIFF
--- a/AudioConfigRP2040.h
+++ b/AudioConfigRP2040.h
@@ -26,12 +26,27 @@
 #define AUDIO_BITS 11
 #endif
 
-#if (RP2040_AUDIO_OUT_MODE == EXTERNAL_DAC_VIA_I2S)  
-#define pBCLK 20
-#define pWS (pBCLK+1)  // CANNOT BE CHANGED, HAS TO BE NEXT TO pBCLK
-#define pDOUT 22
-#define AUDIO_BITS 16
+#if (RP2040_AUDIO_OUT_MODE == EXTERNAL_DAC_VIA_I2S)
+// ****** BEGIN: These are define you may want to change. Best not to touch anything outside this range. ************/
+#define BCLK_PIN 20
+#define WS_PIN (pBCLK+1)  // CANNOT BE CHANGED, HAS TO BE NEXT TO pBCLK
+#define DOUT_PIN 22
+#define LSBJ_FORMAT true   // some DAC, like the PT8211, use a variant of I2S data format called LSBJ
+                           // set this to true to use this kind of DAC or false for plain I2S.
+#define AUDIO_BITS 16   // available values are 8, 16, 24 (LEFT ALIGN in 32 bits type!!) and 32 bits
+// ****** END: These are define you may want to change. Best not to touch anything outside this range. ************/
+
 #define BYPASS_MOZZI_OUTPUT_BUFFER true
+
+// Configuration of the I2S port, especially DMA. Set in stone here as default of the library when this want written.
+// Probably do not change if you are not sure of what you are doing
+#define BUFFERS 8       // number of DMA buffers used
+#if (AUDIO_BITS == 32)
+#define BUFFER_WORDS 32  // number of words in the buffers
+#else
+#define BUFFER_WORDS 16
+#endif
+
 #endif
 
 

--- a/AudioConfigRP2040.h
+++ b/AudioConfigRP2040.h
@@ -31,22 +31,17 @@
 #define BCLK_PIN 20
 #define WS_PIN (pBCLK+1)  // CANNOT BE CHANGED, HAS TO BE NEXT TO pBCLK
 #define DOUT_PIN 22
-#define LSBJ_FORMAT true   // some DAC, like the PT8211, use a variant of I2S data format called LSBJ
+#define LSBJ_FORMAT false   // some DAC, like the PT8211, use a variant of I2S data format called LSBJ
                            // set this to true to use this kind of DAC or false for plain I2S.
 #define AUDIO_BITS 16   // available values are 8, 16, 24 (LEFT ALIGN in 32 bits type!!) and 32 bits
 // ****** END: These are define you may want to change. Best not to touch anything outside this range. ************/
 
 #define BYPASS_MOZZI_OUTPUT_BUFFER true
 
-// Configuration of the I2S port, especially DMA. Set in stone here as default of the library when this want written.
+// Configuration of the I2S port, especially DMA. Set in stone here as default of the library when this was written.
 // Probably do not change if you are not sure of what you are doing
 #define BUFFERS 8       // number of DMA buffers used
-#if (AUDIO_BITS == 32)
-#define BUFFER_WORDS 32  // number of words in the buffers
-#else
-#define BUFFER_WORDS 16
-#endif
-
+#define BUFFER_SIZE 256  // total size of the buffer, in samples
 #endif
 
 

--- a/AudioConfigRP2040.h
+++ b/AudioConfigRP2040.h
@@ -5,14 +5,36 @@
 #error This header should be included for RP2040, only
 #endif
 
+
+// AUDIO output modes
+#define PWM_VIA_BARE_CHIP 1  // output using one of the gpio of the board
+#define EXTERNAL_DAC_VIA_I2S 2  // output via external DAC connected to I2S (PT8211 or similar)
+
+//******* BEGIN: These are the defines you may want to change. Best not to touch anything outside this range. ************/
+#define RP2040_AUDIO_OUT_MODE PWM_VIA_BARE_CHIP
+//******* END: These are the defines you may want to change. Best not to touch anything outside this range. ************/
+
+
+#if (RP2040_AUDIO_OUT_MODE == PWM_VIA_BARE_CHIP)  
 #define AUDIO_CHANNEL_1_PIN 0
 #if (AUDIO_CHANNELS > 1)
 // Audio channel pins for stereo or HIFI must be on the same PWM slice (which is the case for the pairs (0,1), (2,3), (4,5), etc.
-#  define AUDIO_CHANNEL_2_PIN 1
+#define AUDIO_CHANNEL_2_PIN 1
 #endif
 
 // The more audio bits you use, the slower the carrier frequency of the PWM signal. 11 bits yields ~ 60kHz on a 133Mhz CPU (which appears to be a reasonable compromise)
 #define AUDIO_BITS 11
+#endif
+
+#if (RP2040_AUDIO_OUT_MODE == EXTERNAL_DAC_VIA_I2S)  
+#define pBCLK 20
+#define pWS (pBCLK+1)  // CANNOT BE CHANGED, HAS TO BE NEXT TO pBCLK
+#define pDOUT 22
+#define AUDIO_BITS 16
+#define BYPASS_MOZZI_OUTPUT_BUFFER true
+#endif
+
+
 #define AUDIO_BITS_PER_CHANNEL AUDIO_BITS
 
 #define AUDIO_BIAS ((uint16_t) 1<<(AUDIO_BITS-1))

--- a/MozziGuts_impl_RP2040.hpp
+++ b/MozziGuts_impl_RP2040.hpp
@@ -102,14 +102,15 @@ void setupMozziADC(int8_t speed) {
   );
 
   // we want notification, when a sample has arrived
-  dma_channel_set_irq1_enabled(dma_chan, true);
-  irq_add_shared_handler(DMA_IRQ_1, rp2040_adc_queue_handler, PICO_SHARED_IRQ_HANDLER_DEFAULT_ORDER_PRIORITY);
-  irq_set_enabled(DMA_IRQ_1, true);
+  dma_channel_set_irq0_enabled(dma_chan, true);
+  irq_add_shared_handler(DMA_IRQ_0, rp2040_adc_queue_handler, PICO_SHARED_IRQ_HANDLER_DEFAULT_ORDER_PRIORITY);
+  irq_set_enabled(DMA_IRQ_0, true);
   dma_channel_start(dma_chan);
 }
 
 void rp2040_adc_queue_handler() {
-  dma_hw->ints0 = 1u << rp2040_adc_dma_chan;  // clear interrupt flag
+  if (!dma_channel_get_irq0_status(rp2040_adc_dma_chan)) return; // shared handler may get called on unrelated events
+  dma_channel_acknowledge_irq0(rp2040_adc_dma_chan); // clear interrupt flag  
   //adc_run(false);  // adc not running continuous
   //adc_fifo_drain(); // no need to drain fifo, the dma transfer did that
   dma_channel_set_trans_count(rp2040_adc_dma_chan, 1, true);  // set up for another read

--- a/MozziGuts_impl_RP2040.hpp
+++ b/MozziGuts_impl_RP2040.hpp
@@ -239,7 +239,12 @@ static void startAudio() {
   i2s.setBCLK(BCLK_PIN);
   i2s.setDATA(DOUT_PIN);
   i2s.setBitsPerSample(AUDIO_BITS);
-  i2s.setBuffers(BUFFERS, BUFFER_WORDS, 0);
+  
+#if (AUDIO_BITS > 16)
+  i2s.setBuffers(BUFFERS, (size_t) (BUFFER_SIZE/BUFFERS), 0);
+#else
+  i2s.setBuffers(BUFFERS, (size_t) (BUFFER_SIZE/BUFFERS/2), 0);
+#endif
 #if (LSBJ_FORMAT == true)
   i2s.setLSBJFormat();
 #endif

--- a/MozziGuts_impl_RP2040.hpp
+++ b/MozziGuts_impl_RP2040.hpp
@@ -83,6 +83,7 @@ void setupMozziADC(int8_t speed) {
   );
   
   uint dma_chan = dma_claim_unused_channel(true);
+  rp2040_adc_dma_chan = dma_chan;
   static dma_channel_config cfg = dma_channel_get_default_config(dma_chan);
 
   // Reading from constant address, writing to incrementing byte addresses
@@ -102,8 +103,9 @@ void setupMozziADC(int8_t speed) {
 
   // we want notification, when a sample has arrived
   dma_channel_set_irq1_enabled(dma_chan, true);
-  irq_set_exclusive_handler(DMA_IRQ_1, rp2040_adc_queue_handler);
+  irq_add_shared_handler(DMA_IRQ_1, rp2040_adc_queue_handler, PICO_SHARED_IRQ_HANDLER_DEFAULT_ORDER_PRIORITY);
   irq_set_enabled(DMA_IRQ_1, true);
+  dma_channel_start(dma_chan);
 }
 
 void rp2040_adc_queue_handler() {

--- a/MozziGuts_impl_RP2040.hpp
+++ b/MozziGuts_impl_RP2040.hpp
@@ -160,19 +160,6 @@ I2S i2s(OUTPUT);
 inline bool canBufferAudioOutput() {
   return (i2s.availableForWrite());
 }
-/*
-#if (AUDIO_BITS == 8)
-size_t (*i2sWritePtr) (int8_t, int8_t) = &i2s.write8;
-#elif (AUDIO_BITS == 16)
-//size_t (*i2sWritePtr) (int16_t, int16_t) = &i2s.write16;
-size_t (I2S::*i2sWritePtr) (int16_t, int16_t) = &I2S::write16;
-#elif (AUDIO_BITS == 24)
-size_t (*i2sWritePtr) (int32_t, int32_t) = &i2s.write24;
-#elif (AUDIO_BITS == 32)
-size_t (*i2sWritePtr) (int32_t, int32_t) = &i2s.write32;
-#else
-#error The number of AUDIO_BITS in AudioConfigRP2040.h is incorrect
-#endif*/
 
 inline void audioOutput(const AudioOutput f) {
 

--- a/README.md
+++ b/README.md
@@ -291,13 +291,13 @@ on the RP2040 SDK API. Tested on a Pi Pico.
 - Wavetables and samples are not kept in progmem on this platform. While apparently speed (of the external flash) is not much of an issue, the data always seems to be copied into RAM, anyway.
 - Currently, two audio output modes exist (configurable in AudioConfigRP2040.h) in addition to using an user-defined `audioOutput` function, with the default being PWM_VIA_BARE_CHIP:
   - PWM_VIA_BARE_CHIP: PWM audio output on pin 0, by default, with 11 bits default output resolution
-    - One timer interrupt (DMA_IRQ_1) and one DMA channel are claimed (number not hardcoded).
+    - One non-exclusive timer interrupt (DMA_IRQ_0) and one DMA channel are claimed (number not hardcoded).
     - HIFI_MODE not yet implemented (although that should not be too hard to do).
   - EXTERNAL_DAC_VIA_I2S: I2S output to be connected to an external DAC
     - 16 bits resolution by default (configurable in AudioConfigRP2040.h), 8, 16, 24 (left aligned) and 32 resolution are available.
     - Both plain I2S and LSBJ_FORMAT (for the PT8211 for instance) are available (configurable in AudioConfigRP2040.h), default is LSBJ.
     - Outputs pins can be configured in AudioConfigRP2040.h. Default is BCK: 20, WS: 21, DATA: 22.
-    - Two timer interrupts (DMA_IRQ_0 and DMA_IRQ_1) and two DMA channels are claimed (numbers not hardcoded).
+    - One non-exclusive timer interrupts (DMA_IRQ_0) and two DMA channels are claimed (numbers not hardcoded).
     - At the time of writing, LSBJ is only available with github arduino-pico core.
 - Note that AUDIO_INPUT and mozziAnalogRead() return values in the RP2040's full ADC resolution of 0-4095 rather than AVR's 0-1023.
 - twi_nonblock is not ported

--- a/README.md
+++ b/README.md
@@ -289,9 +289,16 @@ on the RP2040 SDK API. Tested on a Pi Pico.
 
 - This is a recent addition, implementation details may still change (currently just PWM driven by a timer; this may be worth changing to a DMA driven output)
 - Wavetables and samples are not kept in progmem on this platform. While apparently speed (of the external flash) is not much of an issue, the data always seems to be copied into RAM, anyway.
-- Audio output is to pin 0, by default, with 11 bits default output resolution
-- One hardware alarm and one DMA channel are claimed (number not hardcoded)
-- HIFI_MODE not yet implemented (although that should not be too hard to do)
+- Currently, two audio output modes exist (configurable in AudioConfigRP2040.h) in addition to using an user-defined `audioOutput` function, with the default being PWM_VIA_BARE_CHIP:
+  - PWM_VIA_BARE_CHIP: PWM audio output on pin 0, by default, with 11 bits default output resolution
+    - One hardware alarm and one DMA channel are claimed (number not hardcoded).
+    - HIFI_MODE not yet implemented (although that should not be too hard to do).
+  - EXTERNAL_DAC_VIA_I2S: I2S output to be connected to an external DAC
+    - 16 bits resolution by default (configurable in AudioConfigRP2040.h), 8, 16, 24 (left aligned) and 32 resolution are available.
+    - Both plain I2S and LSBJ_FORMAT (for the PT8211 for instance) are available (configurable in AudioConfigRP2040.h), default is LSBJ.
+    - Outputs pins can be configured in AudioConfigRP2040.h. Default is BCK: 20, WS: 21, DATA: 22.
+    - Two hardware alarms and two DMA channels are claimed.
+    - At the time of writing, LSBJ is only available with github arduino-pico core.
 - Note that AUDIO_INPUT and mozziAnalogRead() return values in the RP2040's full ADC resolution of 0-4095 rather than AVR's 0-1023.
 - twi_nonblock is not ported
 - Code uses only one CPU core

--- a/README.md
+++ b/README.md
@@ -291,13 +291,13 @@ on the RP2040 SDK API. Tested on a Pi Pico.
 - Wavetables and samples are not kept in progmem on this platform. While apparently speed (of the external flash) is not much of an issue, the data always seems to be copied into RAM, anyway.
 - Currently, two audio output modes exist (configurable in AudioConfigRP2040.h) in addition to using an user-defined `audioOutput` function, with the default being PWM_VIA_BARE_CHIP:
   - PWM_VIA_BARE_CHIP: PWM audio output on pin 0, by default, with 11 bits default output resolution
-    - One hardware alarm and one DMA channel are claimed (number not hardcoded).
+    - One timer interrupt (DMA_IRQ_1) and one DMA channel are claimed (number not hardcoded).
     - HIFI_MODE not yet implemented (although that should not be too hard to do).
   - EXTERNAL_DAC_VIA_I2S: I2S output to be connected to an external DAC
     - 16 bits resolution by default (configurable in AudioConfigRP2040.h), 8, 16, 24 (left aligned) and 32 resolution are available.
     - Both plain I2S and LSBJ_FORMAT (for the PT8211 for instance) are available (configurable in AudioConfigRP2040.h), default is LSBJ.
     - Outputs pins can be configured in AudioConfigRP2040.h. Default is BCK: 20, WS: 21, DATA: 22.
-    - Two hardware alarms and two DMA channels are claimed.
+    - Two timer interrupts (DMA_IRQ_0 and DMA_IRQ_1) and two DMA channels are claimed (numbers not hardcoded).
     - At the time of writing, LSBJ is only available with github arduino-pico core.
 - Note that AUDIO_INPUT and mozziAnalogRead() return values in the RP2040's full ADC resolution of 0-4095 rather than AVR's 0-1023.
 - twi_nonblock is not ported


### PR DESCRIPTION
Hello and happy new year!

I have started fiddling with the RP2040 (what a nice chip!) and as it does possess I2S support, found a bit sad not to use it in order to interface it with some external DAC. Having a native I2S support allows not to have two buffers in row (Mozzi and the I2S output buffer). Also, it uses DMAs.

A few details:
  - there was a IRQ conflict with the implementation of the fast ADC, I add to move the later to IRQ1 instead of IRQ0
  - the buffers size are the default ones from the library, maybe it would be worth to have them editable? I am afraid that I'll led the users to input bad configurations actually.

As a draft for now, it seems to work but I want to test it a bit further.

Best,