### PR TITLE
Compile and runtime error when EXTERNAL_AUDIO_OUTPUT is true

### DIFF
--- a/MozziGuts_impl_ESP32.hpp
+++ b/MozziGuts_impl_ESP32.hpp
@@ -104,11 +104,11 @@ static void startAudio() {
 #if (BYPASS_MOZZI_OUTPUT_BUFFER != true)  // for external audio output, set up a timer running a audio rate
   static intr_handle_t s_timer_handle;
   timer_config_t config = {
-    .alarm_en = true,
-    .counter_en = false,
-    .intr_type = TIMER_INTR_LEVEL,
+    .alarm_en = (timer_alarm_t)true,
+    .counter_en = (timer_start_t)false,
+    .intr_type = (timer_intr_mode_t) TIMER_INTR_LEVEL,
     .counter_dir = TIMER_COUNT_UP,
-    .auto_reload = true,
+    .auto_reload = (timer_autoreload_t) true,
     .divider = 1 // For max available precision: The APB_CLK clock signal is running at 80 MHz, i.e. 1/80 uS per tick
   };
   timer_init(TIMER_GROUP_0, TIMER_0, &config);

--- a/MozziGuts_impl_ESP32.hpp
+++ b/MozziGuts_impl_ESP32.hpp
@@ -37,6 +37,7 @@ void setupMozziADC(int8_t speed) {
 
 
 
+
 //// BEGIN AUDIO OUTPUT code ///////
 #include <driver/i2s.h>   // for I2S-based output modes
 #include <driver/timer.h> // for EXTERNAL_AUDIO_OUTPUT
@@ -103,17 +104,19 @@ void CACHED_FUNCTION_ATTR timer0_audio_output_isr(void *) {
 static void startAudio() {
 #if (BYPASS_MOZZI_OUTPUT_BUFFER != true)  // for external audio output, set up a timer running a audio rate
   static intr_handle_t s_timer_handle;
+  const int div = 2;
   timer_config_t config = {
     .alarm_en = (timer_alarm_t)true,
     .counter_en = (timer_start_t)false,
     .intr_type = (timer_intr_mode_t) TIMER_INTR_LEVEL,
     .counter_dir = TIMER_COUNT_UP,
     .auto_reload = (timer_autoreload_t) true,
-    .divider = 1 // For max available precision: The APB_CLK clock signal is running at 80 MHz, i.e. 1/80 uS per tick
+    .divider = div // For max available precision: The APB_CLK clock signal is running at 80 MHz, i.e. 2/80 uS per tick
+                 // Min acceptable value is 2
   };
   timer_init(TIMER_GROUP_0, TIMER_0, &config);
   timer_set_counter_value(TIMER_GROUP_0, TIMER_0, 0);
-  timer_set_alarm_value(TIMER_GROUP_0, TIMER_0, 80000000UL / AUDIO_RATE);
+  timer_set_alarm_value(TIMER_GROUP_0, TIMER_0, 80000000UL / AUDIO_RATE / div);
   timer_enable_intr(TIMER_GROUP_0, TIMER_0);
   timer_isr_register(TIMER_GROUP_0, TIMER_0, &timer0_audio_output_isr, nullptr, 0, &s_timer_handle);
   timer_start(TIMER_GROUP_0, TIMER_0);

--- a/mozzi_config.h
+++ b/mozzi_config.h
@@ -104,8 +104,8 @@ compile time.
 Defining this option as true in mozzi_config.h allows to completely customize the audio output, e.g. for connecting to external DACs.
 For more detail, @see AudioOuput .
 */
-//#define EXTERNAL_AUDIO_OUTPUT false
-#define EXTERNAL_AUDIO_OUTPUT true
+#define EXTERNAL_AUDIO_OUTPUT false
+//#define EXTERNAL_AUDIO_OUTPUT true
 
 /** @ingroup core
 Only used when EXTERNAL_AUDIO_OUTPUT is set to true: The resolution to use for audio samples, internally. You will usually set this to match the

--- a/mozzi_config.h
+++ b/mozzi_config.h
@@ -104,8 +104,8 @@ compile time.
 Defining this option as true in mozzi_config.h allows to completely customize the audio output, e.g. for connecting to external DACs.
 For more detail, @see AudioOuput .
 */
-#define EXTERNAL_AUDIO_OUTPUT false
-//#define EXTERNAL_AUDIO_OUTPUT true
+//#define EXTERNAL_AUDIO_OUTPUT false
+#define EXTERNAL_AUDIO_OUTPUT true
 
 /** @ingroup core
 Only used when EXTERNAL_AUDIO_OUTPUT is set to true: The resolution to use for audio samples, internally. You will usually set this to match the


### PR DESCRIPTION
On an ESP32, when setting the EXTERNAL_AUDIO_OUTPUT to true I was running into compile errors.
After correcting them, I was running into runtime errors in my tests because the divider of 1 is not allowed.
After this correction the functionality is working again.
