### PR TITLE
Add auto-builds for ESP8266

### DIFF
--- a/.github/workflows/compile_examples.yml
+++ b/.github/workflows/compile_examples.yml
@@ -36,7 +36,18 @@ jobs:
           - fqbn: arduino:avr:uno
             platforms: |
               - name: arduino:avr
+          - fqbn: esp8266:esp8266:huzzah
+            type: 8266
+            platforms: |
+              - name: esp8266:esp8266
+                source-url: https://arduino.esp8266.com/stable/package_esp8266com_index.json
 
+        exclude:
+          - board:
+              type: esp8266
+              sketch-paths: |
+                - examples/03.Sensors/Sinewave_Pinchange_Interrupt
+              
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/compile_examples.yml
+++ b/.github/workflows/compile_examples.yml
@@ -42,12 +42,6 @@ jobs:
               - name: esp8266:esp8266
                 source-url: https://arduino.esp8266.com/stable/package_esp8266com_index.json
 
-        exclude:
-          - board:
-              type: esp8266
-              sketch-paths: |
-                - examples/03.Sensors/Sinewave_Pinchange_Interrupt
-              
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -62,7 +56,7 @@ jobs:
           sketch-paths: |
             - examples/01.Basics
             - examples/02.Control
-            - examples/03.Sensors
+            - examples/06.Synthesis
           libraries: |
             - source-path: ./
             - name: PinChangeInterrupt

--- a/MozziGuts_impl_ESP8266.hpp
+++ b/MozziGuts_impl_ESP8266.hpp
@@ -41,7 +41,7 @@ void setupMozziADC(int8_t speed) {
 #define LOOP_YIELD yield();
 
 #include <uart.h>
-#include <i2s.h>
+#include <I2S.h>
 uint16_t output_buffer_size = 0;
 
 #if (EXTERNAL_AUDIO_OUTPUT != true) // otherwise, the last stage - audioOutput() - will be provided by the user

--- a/examples/02.Control/Line_Gliss/Line_Gliss.ino
+++ b/examples/02.Control/Line_Gliss/Line_Gliss.ino
@@ -28,13 +28,13 @@
 #include <MozziGuts.h>
 #include <Line.h> // for smooth transitions
 #include <Oscil.h> // oscillator template
-#include <tables/triangle_warm8192_int8.h> // triangle table for oscillator
+#include <tables/saw8192_int8.h> // saw table for oscillator
 #include <mozzi_midi.h>
 
 #define CONTROL_RATE 64 // Hz, powers of 2 are most reliable
 
 // use: Oscil <table_size, update_rate> oscilName (wavetable), look in .h file of table #included above
-Oscil <TRIANGLE_WARM8192_NUM_CELLS, AUDIO_RATE> aTriangle(TRIANGLE_WARM8192_DATA);
+Oscil <SAW8192_NUM_CELLS, AUDIO_RATE> aSaw(SAW8192_DATA);
 
 // use: Line <type> lineName
 Line <long> aGliss;
@@ -75,8 +75,8 @@ void updateControl(){
 
     // find the phase increments (step sizes) through the audio table for those freqs
     // they are big ugly numbers which the oscillator understands but you don't really want to know
-    long gliss_start = aTriangle.phaseIncFromFreq(start_freq);
-    long gliss_end = aTriangle.phaseIncFromFreq(end_freq);
+    long gliss_start = aSaw.phaseIncFromFreq(start_freq);
+    long gliss_end = aSaw.phaseIncFromFreq(end_freq);
 
     // set the audio rate line to transition between the different step sizes
     aGliss.set(gliss_start, gliss_end, audio_steps_per_gliss);
@@ -87,6 +87,6 @@ void updateControl(){
 
 
 AudioOutput_t updateAudio(){
-  aTriangle.setPhaseInc(aGliss.next());
-  return MonoOutput::from8Bit(aTriangle.next());
+  aSaw.setPhaseInc(aGliss.next());
+  return MonoOutput::from8Bit(aSaw.next());
 }


### PR DESCRIPTION
This PR is mostly just to make you aware of what I just discovered: It is not so very hard to have automated test builds for all of our boards / examples.

This is still suffering from a few problems, importantly, because not all examples can be compiled for all boards, but looks immensely useful to me, and already helped to find to spot some problems.

See https://github.com/arduino/compile-sketches for more info (would be cool if you could help me bring more boards, and more examples into the builds.) 