### PR TITLE
Fixed External audio output

### DIFF
--- a/MozziGuts.cpp
+++ b/MozziGuts.cpp
@@ -44,15 +44,7 @@ static void CACHED_FUNCTION_ATTR defaultAudioOutput();
 #endif
 
 
-// forward-declarations for use in hardware-specific implementations:
-//static void advanceADCStep();
 static uint8_t adc_count = 0;
-#if (AUDIO_OUTPUT_OUTSIDE_CALLBACK)
-volatile bool audio_output_requested = false;
-#endif
-
-// forward-declarations; to be supplied by plaform specific implementations
-//static void startSecondADCReadOnCurrentChannel();
 
 ////// BEGIN Output buffering /////
 #if BYPASS_MOZZI_OUTPUT_BUFFER == true
@@ -76,11 +68,7 @@ static void CACHED_FUNCTION_ATTR defaultAudioOutput() {
   adc_count = 0;
   startSecondADCReadOnCurrentChannel();  // the current channel is the AUDIO_INPUT pin
 #  endif
-#if (AUDIO_OUTPUT_OUTSIDE_CALLBACK == true)
-  audio_output_requested = true;
-  #else
   audioOutput(output_buffer.read());
-  #endif
 }
 #endif
 ////// END Output buffering ///////
@@ -222,14 +210,11 @@ void audioHook() // 2us on AVR excluding updateAudio()
     LOOP_YIELD
 #endif      
       }
-  // setPin13Low();
-#if (AUDIO_OUTPUT_OUTSIDE_CALLBACK)
-  if (audio_output_requested)
-    {
-      audioOutput(output_buffer.read());
-      audio_output_requested = false;
-    }
+// Like LOOP_YIELD, but running every cycle of audioHook(), not just once per sample
+#if defined(AUDIO_HOOK_HOOK)
+    AUDIO_HOOK_HOOK
 #endif
+  // setPin13Low();
 }
 
 // NOTE: This function counts the ticks of audio _output_, corresponding to real time elapsed.

--- a/MozziGuts.cpp
+++ b/MozziGuts.cpp
@@ -21,7 +21,9 @@
 // forward-declarations for use in hardware-specific implementations:
 static void advanceADCStep();
 static uint8_t adc_count = 0;
+#if (AUDIO_OUTPUT_OUTSIDE_CALLBACK)
 volatile bool audio_output_requested = false;
+#endif
 
 // forward-declarations; to be supplied by plaform specific implementations
 static void startSecondADCReadOnCurrentChannel();

--- a/MozziGuts.cpp
+++ b/MozziGuts.cpp
@@ -18,15 +18,41 @@
 //#include "mozzi_utils.h"
 #include "AudioOutput.h"
 
+
+// Forward declaration
+static void CACHED_FUNCTION_ATTR defaultAudioOutput();
+
+// Include the appropriate implementation
+#if IS_AVR()
+#  include "MozziGuts_impl_AVR.hpp"
+#elif IS_STM32()
+#  include "MozziGuts_impl_STM32.hpp"
+#elif IS_ESP32()
+#  include "MozziGuts_impl_ESP32.hpp"
+#elif IS_ESP8266()
+#  include "MozziGuts_impl_ESP8266.hpp"
+#elif (IS_TEENSY3() || IS_TEENSY4())
+#  include "MozziGuts_impl_TEENSY.hpp"
+#elif (IS_SAMD21())
+#  include "MozziGuts_impl_SAMD.hpp"
+#elif (IS_RP2040())
+#  include "MozziGuts_impl_RP2040.hpp"
+#elif (IS_MBED())
+#  include "MozziGuts_impl_MBED.hpp"
+#else
+#  error "Platform not (yet) supported. Check MozziGuts_impl_template.hpp and existing implementations for a blueprint for adding your favorite MCU."
+#endif
+
+
 // forward-declarations for use in hardware-specific implementations:
-static void advanceADCStep();
+//static void advanceADCStep();
 static uint8_t adc_count = 0;
 #if (AUDIO_OUTPUT_OUTSIDE_CALLBACK)
 volatile bool audio_output_requested = false;
 #endif
 
 // forward-declarations; to be supplied by plaform specific implementations
-static void startSecondADCReadOnCurrentChannel();
+//static void startSecondADCReadOnCurrentChannel();
 
 ////// BEGIN Output buffering /////
 #if BYPASS_MOZZI_OUTPUT_BUFFER == true
@@ -59,27 +85,6 @@ static void CACHED_FUNCTION_ATTR defaultAudioOutput() {
 #endif
 ////// END Output buffering ///////
 
-
-// Include the appropriate implementation
-#if IS_AVR()
-#  include "MozziGuts_impl_AVR.hpp"
-#elif IS_STM32()
-#  include "MozziGuts_impl_STM32.hpp"
-#elif IS_ESP32()
-#  include "MozziGuts_impl_ESP32.hpp"
-#elif IS_ESP8266()
-#  include "MozziGuts_impl_ESP8266.hpp"
-#elif (IS_TEENSY3() || IS_TEENSY4())
-#  include "MozziGuts_impl_TEENSY.hpp"
-#elif (IS_SAMD21())
-#  include "MozziGuts_impl_SAMD.hpp"
-#elif (IS_RP2040())
-#  include "MozziGuts_impl_RP2040.hpp"
-#elif (IS_MBED())
-#  include "MozziGuts_impl_MBED.hpp"
-#else
-#  error "Platform not (yet) supported. Check MozziGuts_impl_template.hpp and existing implementations for a blueprint for adding your favorite MCU."
-#endif
 
 
 ////// BEGIN Analog input code ////////
@@ -215,17 +220,16 @@ void audioHook() // 2us on AVR excluding updateAudio()
 
 #if defined(LOOP_YIELD)
     LOOP_YIELD
-#endif
-      
-#if (AUDIO_OUTPUT_OUTSIDE_CALLBACK)
-      if (audio_output_requested)
-	{
-	  audioOutput(output_buffer.read());
-	  audio_output_requested = false;
-	}
-	#endif
-  }
+#endif      
+      }
   // setPin13Low();
+#if (AUDIO_OUTPUT_OUTSIDE_CALLBACK)
+  if (audio_output_requested)
+    {
+      audioOutput(output_buffer.read());
+      audio_output_requested = false;
+    }
+#endif
 }
 
 // NOTE: This function counts the ticks of audio _output_, corresponding to real time elapsed.

--- a/MozziGuts.h
+++ b/MozziGuts.h
@@ -199,7 +199,6 @@ HIFI is not available/not required on Teensy 3.* or ARM.
 #define EXTERNAL_AUDIO_OUTPUT false
 #endif
 
-
 #if (EXTERNAL_AUDIO_OUTPUT != true)
 #if IS_TEENSY3()
 #include "AudioConfigTeensy3_12bit.h"

--- a/MozziGuts.h
+++ b/MozziGuts.h
@@ -199,6 +199,7 @@ HIFI is not available/not required on Teensy 3.* or ARM.
 #define EXTERNAL_AUDIO_OUTPUT false
 #endif
 
+
 #if (EXTERNAL_AUDIO_OUTPUT != true)
 #if IS_TEENSY3()
 #include "AudioConfigTeensy3_12bit.h"

--- a/MozziGuts_impl_MBED.hpp
+++ b/MozziGuts_impl_MBED.hpp
@@ -164,6 +164,11 @@ void stopMozzi() {
 #include <mbed.h>
 #include <pinDefinitions.h>
 mbed::Ticker audio_output_timer;
+
+#if (EXTERNAL_AUDIO_OUTPUT == true)
+#define AUDIO_OUTPUT_OUTSIDE_CALLBACK true
+#endif
+
 #if (MBED_AUDIO_OUT_MODE == TIMEDPWM && EXTERNAL_AUDIO_OUTPUT != true)
 #define US_PER_PWM_CYCLE (US_PER_AUDIO_TICK)
 mbed::PwmOut pwmpin1(digitalPinToPinName(AUDIO_CHANNEL_1_PIN));
@@ -179,7 +184,7 @@ inline void audioOutput(const AudioOutput f) {
   pwmpin2.write(.5 + (float) f.r() / ((float) (1L << AUDIO_BITS)));
 #endif
 }
-#endif
+#endif  // #if (MBED_AUDIO_OUT_MODE == TIMEDPWM && EXTERNAL_AUDIO_OUTPUT != true)
 
 static void startAudio() {
 #if (MBED_AUDIO_OUT_MODE == TIMEDPWM && EXTERNAL_AUDIO_OUTPUT != true)

--- a/MozziGuts_impl_MBED.hpp
+++ b/MozziGuts_impl_MBED.hpp
@@ -163,10 +163,10 @@ void stopMozzi() {
 #define US_PER_AUDIO_TICK (1000000L / AUDIO_RATE)
 #include <mbed.h>
 #include <pinDefinitions.h>
-#if (MBED_AUDIOw_OUT_MODE == TIMEDPWM)
+mbed::Ticker audio_output_timer;
+#if (MBED_AUDIO_OUT_MODE == TIMEDPWM && EXTERNAL_AUDIO_OUTPUT != true)
 #define US_PER_PWM_CYCLE (US_PER_AUDIO_TICK)
 mbed::PwmOut pwmpin1(digitalPinToPinName(AUDIO_CHANNEL_1_PIN));
-mbed::Ticker audio_output_timer;
 #if (AUDIO_CHANNELS > 1)
 mbed::PwmOut pwmpin2(digitalPinToPinName(AUDIO_CHANNEL_2_PIN));
 #endif
@@ -182,7 +182,7 @@ inline void audioOutput(const AudioOutput f) {
 #endif
 
 static void startAudio() {
-#if (MBED_AUDIO_OUT_MODE == TIMEDPWM)
+#if (MBED_AUDIO_OUT_MODE == TIMEDPWM && EXTERNAL_AUDIO_OUTPUT != true)
   pwmpin1.period_us(US_PER_UPDATE);
   pwmpin1.write(.5);
   #if (AUDIO_CHANNELS > 1)

--- a/MozziGuts_impl_MBED.hpp
+++ b/MozziGuts_impl_MBED.hpp
@@ -166,7 +166,13 @@ void stopMozzi() {
 mbed::Ticker audio_output_timer;
 
 #if (EXTERNAL_AUDIO_OUTPUT == true)
-#define AUDIO_OUTPUT_OUTSIDE_CALLBACK true
+volatile bool audio_output_requested = false;
+inline void defaultAudioOutputCallback() {
+  audio_output_requested = true;
+}
+#define AUDIO_HOOK_HOOK { if (audio_output_requested) { audio_output_requested = false; defaultAudioOutput(); } }
+#else
+#define defaultAudioOutputCallback defaultAudioOutput
 #endif
 
 #if (MBED_AUDIO_OUT_MODE == TIMEDPWM && EXTERNAL_AUDIO_OUTPUT != true)
@@ -195,7 +201,7 @@ static void startAudio() {
   pwmpin2.write(.5);
   #endif
 #endif
-  audio_output_timer.attach_us(&defaultAudioOutput, US_PER_AUDIO_TICK);
+  audio_output_timer.attach_us(&defaultAudioOutputCallback, US_PER_AUDIO_TICK);
 }
 
 void stopMozzi() {


### PR DESCRIPTION
This is just a small tweak to make EXTERNAL_AUDIO_OUTPUT working. Tested crudefully with a digital output, will try to hook up a real DAC today.

Note: I did not get why I had to change `#if (MBED_AUDIO_OUT_MODE == TIMEDPWM && EXTERNAL_AUDIO_OUTPUT != true)` : I was initially thinking that, as I did not changed the MBED config, `MBED_AUDIO_OUT_MODE == TIMEDPWM` would be false. Shouldn't `AudioConfigMBED.h` be included? I did not go very deep yet.

Let me know if you think me making commits on this branch is not helpful!


