### PR TITLE
Initial Arduino Giga port

### DIFF
--- a/.github/workflows/compile_examples.yml
+++ b/.github/workflows/compile_examples.yml
@@ -44,6 +44,7 @@ jobs:
           - fqbn: arduino:mbed_giga:giga
             platforms: |
               - name: arduino:mbed_giga
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -63,6 +64,7 @@ jobs:
             - source-path: ./
             - name: PinChangeInterrupt
             - name: MIDI Library
+            - name: Advanced_Analog
           enable-deltas-report: true
           sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}
 

--- a/.github/workflows/compile_examples.yml
+++ b/.github/workflows/compile_examples.yml
@@ -41,7 +41,9 @@ jobs:
             platforms: |
               - name: esp8266:esp8266
                 source-url: https://arduino.esp8266.com/stable/package_esp8266com_index.json
-
+          - fqbn: arduino:mbed_giga:giga
+            platforms: |
+              - name: arduino:mbed_giga
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/compile_examples.yml
+++ b/.github/workflows/compile_examples.yml
@@ -64,7 +64,7 @@ jobs:
             - source-path: ./
             - name: PinChangeInterrupt
             - name: MIDI Library
-            - name: Advanced_Analog
+            - name: Arduino_AdvancedAnalog
           enable-deltas-report: true
           sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}
 

--- a/AudioConfigMBED.h
+++ b/AudioConfigMBED.h
@@ -11,11 +11,18 @@
 
 // Audio output options
 #define INTERNAL_DAC 1 // output using internal DAC driven via DMA. Output is only possible on the DAC pins (A12, and A13 on the Giga)
-#define TIMED_PWM 2    // BROKEN: output using PWM updated by a timer at audio rate. Less efficient, but should be most portable, and allows to use any PWM capable pin for output.
-//#define PDM_VIA_I2S 3 // output PDM coded sample on the I2S data pin
+#define PDM_VIA_SERIAL 2 // output PDM coded sample on a hardware serial UART. NOTE: currently to be considered experimental. Tune is not correct for all combinatinos of AUDIO_RATE & PDM_RESOLUTION
+                         // Also NOTE that you will almost certainly want to use at least some basic RC filter circuit with this mode
 
 // Set output mode
 #define MBED_AUDIO_OUT_MODE INTERNAL_DAC
+
+#if (MBED_AUDIO_OUT_MODE == PDM_VIA_SERIAL)
+// For use in PDM_VIA_SERIAL, only: Peripheral to use. Note that only the TX channel is actually used, but sine this is a hardware UART, the corresponding
+// RX channel needs to be claimed, as well. NOTE: This does not necessarily correspond to the labeling on your board! E.g. SERIAL2_TX is TX1 on the Arduino Giga.
+#define PDM_SERIAL_UART_TX_CHANNEL_1 SERIAL2_TX
+#define PDM_SERIAL_UART_RX_CHANNEL_1 SERIAL2_RX
+#endif
 
 /// User config end. Do not modify below this line
 
@@ -24,13 +31,10 @@
 #define AUDIO_CHANNEL_1_PIN A12
 #define AUDIO_CHANNEL_2_PIN A13
 #define BYPASS_MOZZI_OUTPUT_BUFFER true
-#elif (MBED_AUDIO_OUT_MODE == TIMED_PWM)
+#elif (MBED_AUDIO_OUT_MODE == PDM_VIA_SERIAL)
 #define AUDIO_BITS 16  // well, used internally, at least. The pins will not be able to actually produce this many bits
-#define AUDIO_CHANNEL_1_PIN D8
-#define AUDIO_CHANNEL_2_PIN D9
-/*#elif (ESP32_AUDIO_OUT_MODE == PDM_VIA_I2S)
-#define AUDIO_BITS 16
-#define PDM_RESOLUTION 4 */
+#define PDM_RESOLUTION 2
+#define BYPASS_MOZZI_OUTPUT_BUFFER true
 #else
 #error Invalid output mode configured in AudioConfigMBED.h
 #endif

--- a/AudioConfigMBED.h
+++ b/AudioConfigMBED.h
@@ -10,30 +10,25 @@
 #endif
 
 // Audio output options
-#define INTERNAL_DAC 1 // output using internal DAC via I2S, output on pin 26
-//#define PT8211_DAC 2 // output using an external PT8211 DAC via I2S
-//#define PDM_VIA_I2S 3 // output PDM coded sample on the I2S data pin (pin 33, by default, configurable, below)
+#define INTERNAL_DAC 1 // output using internal DAC driven via DMA. Output is only possible on the DAC pins (A12, and A13 on the Giga)
+#define TIMED_PWM 2    // BROKEN: output using PWM updated by a timer at audio rate. Less efficient, but should be most portable, and allows to use any PWM capable pin for output.
+//#define PDM_VIA_I2S 3 // output PDM coded sample on the I2S data pin
 
 // Set output mode
 #define MBED_AUDIO_OUT_MODE INTERNAL_DAC
 
-// For external I2S output, only: I2S_PINS
-//#define ESP32_I2S_BCK_PIN 26
-//#define ESP32_I2S_WS_PIN 25
-//#define ESP32_I2S_DATA_PIN 33
-
-//#include <driver/i2s.h>
-//const i2s_port_t i2s_num = I2S_NUM_0;
 /// User config end. Do not modify below this line
 
 #if (MBED_AUDIO_OUT_MODE == INTERNAL_DAC)
 #define AUDIO_BITS 12
 #define AUDIO_CHANNEL_1_PIN A12
 #define AUDIO_CHANNEL_2_PIN A13
-/*#elif (ESP32_AUDIO_OUT_MODE == PT8211_DAC)
-#define AUDIO_BITS 16
-#define PDM_RESOLUTION 1
-#elif (ESP32_AUDIO_OUT_MODE == PDM_VIA_I2S)
+#define BYPASS_MOZZI_OUTPUT_BUFFER true
+#elif (MBED_AUDIO_OUT_MODE == TIMED_PWM)
+#define AUDIO_BITS 16  // well, used internally, at least. The pins will not be able to actually produce this many bits
+#define AUDIO_CHANNEL_1_PIN D8
+#define AUDIO_CHANNEL_2_PIN D9
+/*#elif (ESP32_AUDIO_OUT_MODE == PDM_VIA_I2S)
 #define AUDIO_BITS 16
 #define PDM_RESOLUTION 4 */
 #else
@@ -41,6 +36,5 @@
 #endif
 
 #define AUDIO_BIAS ((uint16_t) 1<<(AUDIO_BITS-1))
-#define BYPASS_MOZZI_OUTPUT_BUFFER true
 
 #endif        //  #ifndef AUDIOCONFIGMBED_H

--- a/AudioConfigMBED.h
+++ b/AudioConfigMBED.h
@@ -1,0 +1,46 @@
+#ifndef AUDIOCONFIGMBED_H
+#define AUDIOCONFIGMBED_H
+
+#if not IS_MBED()
+#error This header should be included for MBED OS boards, only
+#endif
+
+#if (AUDIO_MODE == HIFI)
+#error HIFI mode is not available for this CPU architecture (but several high quality output options are available)
+#endif
+
+// Audio output options
+#define INTERNAL_DAC 1 // output using internal DAC via I2S, output on pin 26
+//#define PT8211_DAC 2 // output using an external PT8211 DAC via I2S
+//#define PDM_VIA_I2S 3 // output PDM coded sample on the I2S data pin (pin 33, by default, configurable, below)
+
+// Set output mode
+#define MBED_AUDIO_OUT_MODE INTERNAL_DAC
+
+// For external I2S output, only: I2S_PINS
+//#define ESP32_I2S_BCK_PIN 26
+//#define ESP32_I2S_WS_PIN 25
+//#define ESP32_I2S_DATA_PIN 33
+
+//#include <driver/i2s.h>
+//const i2s_port_t i2s_num = I2S_NUM_0;
+/// User config end. Do not modify below this line
+
+#if (MBED_AUDIO_OUT_MODE == INTERNAL_DAC)
+#define AUDIO_BITS 12
+#define AUDIO_CHANNEL_1_PIN A12
+#define AUDIO_CHANNEL_2_PIN A13
+/*#elif (ESP32_AUDIO_OUT_MODE == PT8211_DAC)
+#define AUDIO_BITS 16
+#define PDM_RESOLUTION 1
+#elif (ESP32_AUDIO_OUT_MODE == PDM_VIA_I2S)
+#define AUDIO_BITS 16
+#define PDM_RESOLUTION 4 */
+#else
+#error Invalid output mode configured in AudioConfigMBED.h
+#endif
+
+#define AUDIO_BIAS ((uint16_t) 1<<(AUDIO_BITS-1))
+#define BYPASS_MOZZI_OUTPUT_BUFFER true
+
+#endif        //  #ifndef AUDIOCONFIGMBED_H

--- a/AudioConfigMBED.h
+++ b/AudioConfigMBED.h
@@ -28,8 +28,8 @@
 
 #if (MBED_AUDIO_OUT_MODE == INTERNAL_DAC)
 #define AUDIO_BITS 12
-#define AUDIO_CHANNEL_1_PIN A12
-#define AUDIO_CHANNEL_2_PIN A13
+#define AUDIO_CHANNEL_1_PIN A13
+#define AUDIO_CHANNEL_2_PIN A12
 #define BYPASS_MOZZI_OUTPUT_BUFFER true
 #elif (MBED_AUDIO_OUT_MODE == PDM_VIA_SERIAL)
 #define AUDIO_BITS 16  // well, used internally, at least. The pins will not be able to actually produce this many bits

--- a/MozziGuts.cpp
+++ b/MozziGuts.cpp
@@ -18,12 +18,33 @@
 //#include "mozzi_utils.h"
 #include "AudioOutput.h"
 
-// forward-declarations for use in hardware-specific implementations:
-static void advanceADCStep();
-static uint8_t adc_count = 0;
 
-// forward-declarations; to be supplied by plaform specific implementations
-static void startSecondADCReadOnCurrentChannel();
+// Forward declaration
+static void CACHED_FUNCTION_ATTR defaultAudioOutput();
+
+// Include the appropriate implementation
+#if IS_AVR()
+#  include "MozziGuts_impl_AVR.hpp"
+#elif IS_STM32()
+#  include "MozziGuts_impl_STM32.hpp"
+#elif IS_ESP32()
+#  include "MozziGuts_impl_ESP32.hpp"
+#elif IS_ESP8266()
+#  include "MozziGuts_impl_ESP8266.hpp"
+#elif (IS_TEENSY3() || IS_TEENSY4())
+#  include "MozziGuts_impl_TEENSY.hpp"
+#elif (IS_SAMD21())
+#  include "MozziGuts_impl_SAMD.hpp"
+#elif (IS_RP2040())
+#  include "MozziGuts_impl_RP2040.hpp"
+#elif (IS_MBED())
+#  include "MozziGuts_impl_MBED.hpp"
+#else
+#  error "Platform not (yet) supported. Check MozziGuts_impl_template.hpp and existing implementations for a blueprint for adding your favorite MCU."
+#endif
+
+
+static uint8_t adc_count = 0;
 
 ////// BEGIN Output buffering /////
 #if BYPASS_MOZZI_OUTPUT_BUFFER == true
@@ -53,29 +74,8 @@ static void CACHED_FUNCTION_ATTR defaultAudioOutput() {
 ////// END Output buffering ///////
 
 
-// Include the appropriate implementation
-#if IS_AVR()
-#  include "MozziGuts_impl_AVR.hpp"
-#elif IS_STM32()
-#  include "MozziGuts_impl_STM32.hpp"
-#elif IS_ESP32()
-#  include "MozziGuts_impl_ESP32.hpp"
-#elif IS_ESP8266()
-#  include "MozziGuts_impl_ESP8266.hpp"
-#elif (IS_TEENSY3() || IS_TEENSY4())
-#  include "MozziGuts_impl_TEENSY.hpp"
-#elif (IS_SAMD21())
-#  include "MozziGuts_impl_SAMD.hpp"
-#elif (IS_RP2040())
-#  include "MozziGuts_impl_RP2040.hpp"
-#elif (IS_MBED())
-#  include "MozziGuts_impl_MBED.hpp"
-#else
-#  error "Platform not (yet) supported. Check MozziGuts_impl_template.hpp and existing implementations for a blueprint for adding your favorite MCU."
-#endif
 
-
-////// BEGIN Analog inpput code ////////
+////// BEGIN Analog input code ////////
 /* Analog input code was informed initially by a discussion between
 jRaskell, bobgardner, theusch, Koshchi, and code by jRaskell.
 http://www.avrfreaks.net/index.php?name=PNphpBB2&file=viewtopic&p=789581
@@ -208,8 +208,12 @@ void audioHook() // 2us on AVR excluding updateAudio()
 
 #if defined(LOOP_YIELD)
     LOOP_YIELD
+#endif      
+      }
+// Like LOOP_YIELD, but running every cycle of audioHook(), not just once per sample
+#if defined(AUDIO_HOOK_HOOK)
+    AUDIO_HOOK_HOOK
 #endif
-  }
   // setPin13Low();
 }
 

--- a/MozziGuts.cpp
+++ b/MozziGuts.cpp
@@ -19,10 +19,12 @@
 #include "AudioOutput.h"
 
 
-// Forward declaration
+// Forward declarations of functions to be provided by platform specific implementations
 #if (!BYPASS_MOZZI_OUTPUT_BUFFER)
 static void CACHED_FUNCTION_ATTR defaultAudioOutput();
 #endif
+static void advanceADCStep();
+static void startSecondADCReadOnCurrentChannel();
 
 // Include the appropriate implementation
 #if IS_AVR()

--- a/MozziGuts.cpp
+++ b/MozziGuts.cpp
@@ -20,7 +20,9 @@
 
 
 // Forward declaration
+#if (!BYPASS_MOZZI_OUTPUT_BUFFER)
 static void CACHED_FUNCTION_ATTR defaultAudioOutput();
+#endif
 
 // Include the appropriate implementation
 #if IS_AVR()

--- a/MozziGuts.cpp
+++ b/MozziGuts.cpp
@@ -68,6 +68,8 @@ static void CACHED_FUNCTION_ATTR defaultAudioOutput() {
 #  include "MozziGuts_impl_SAMD.hpp"
 #elif (IS_RP2040())
 #  include "MozziGuts_impl_RP2040.hpp"
+#elif (IS_MBED())
+#  include "MozziGuts_impl_MBED.hpp"
 #else
 #  error "Platform not (yet) supported. Check MozziGuts_impl_template.hpp and existing implementations for a blueprint for adding your favorite MCU."
 #endif

--- a/MozziGuts.h
+++ b/MozziGuts.h
@@ -214,6 +214,8 @@ HIFI is not available/not required on Teensy 3.* or ARM.
 #include "AudioConfigSAMD21.h"
 #elif IS_RP2040()
 #include "AudioConfigRP2040.h"
+#elif IS_MBED()
+#include "AudioConfigMBED.h"
 #elif IS_AVR() && (AUDIO_MODE == STANDARD)
 #include "AudioConfigStandard9bitPwm.h"
 #elif IS_AVR() && (AUDIO_MODE == STANDARD_PLUS)

--- a/MozziGuts_impl_ESP8266.hpp
+++ b/MozziGuts_impl_ESP8266.hpp
@@ -41,7 +41,7 @@ void setupMozziADC(int8_t speed) {
 #define LOOP_YIELD yield();
 
 #include <uart.h>
-#include <i2s.h>
+#include <I2S.h>
 uint16_t output_buffer_size = 0;
 
 #if (EXTERNAL_AUDIO_OUTPUT != true) // otherwise, the last stage - audioOutput() - will be provided by the user

--- a/MozziGuts_impl_MBED.hpp
+++ b/MozziGuts_impl_MBED.hpp
@@ -1,0 +1,158 @@
+/*
+ * MozziGuts.cpp
+ *
+ * Copyright 2012 Tim Barrass.
+ *
+ * This file is part of Mozzi.
+ *
+ * Mozzi by Tim Barrass is licensed under a Creative Commons
+ * Attribution-NonCommercial-ShareAlike 4.0 International License.
+ *
+ */
+
+/** README! 
+ * This file is meant to be used as a template when adding support for a new platform. Please read these instructions, first.
+ *
+ *  Files involved:
+ *  1. Modify hardware_defines.h, adding a macro to detect your target platform
+ *  2. Modify MozziGuts.cpp to include MozziGuts_impl_YOURPLATFORM.hpp
+ *  3. Modify MozziGuts.h to include AudioConfigYOURPLATFORM.h
+ *  4. Copy this file to MozziGuts_impl_YOURPLATFORM.hpp and adjust as necessary
+ *  (If your platform is very similar to an existing port, it may instead be better to modify the existing MozziGuts_impl_XYZ.hpp/AudioConfigYOURPLATFORM.h,
+ *  instead of steps 2-3.).
+ *  Some platforms may need small modifications to other files as well, e.g. mozzi_pgmspace.h
+ *
+ *  How to implement MozziGuts_impl_YOURPLATFORM.hpp:
+ *  - Follow the NOTEs provided in this file
+ *  - Read the doc at the top of AudioOutput.h for a better understanding of the basic audio output framework
+ *  - Take a peek at existing implementations for other hardware (e.g. TEENSY3/4 is rather complete while also simple at the time of this writing)
+ *  - Wait for more documentation to arrive
+ *  - Ask when in doubt
+ *  - Don't forget to provide a PR when done (it does not have to be perfect; e.g. many ports skip analog input, initially)
+ */
+
+// The main point of this check is to document, what platform & variants this implementation file is for.
+#if !(IS_MBED())
+#  error "Wrong implementation included for this platform"
+#endif
+// Add platform specific includes and declarations, here
+
+
+////// BEGIN analog input code ////////
+
+/** NOTE: This section deals with implementing (fast) asynchronous analog reads, which form the backbone of mozziAnalogRead(), but also of USE_AUDIO_INPUT (if enabled).
+ *  This template provides empty/dummy implementations to allow you to skip over this section, initially. Once you have an implementation, be sure to enable the
+ *  #define, below: */
+//#define MOZZI_FAST_ANALOG_IMPLEMENTED
+
+// Insert here code to read the result of the latest asynchronous conversion, when it is finished.
+// You can also provide this as a function returning unsigned int, should it be more complex on your platform
+#define getADCReading() 0
+
+/** NOTE: On "pins" vs. "channels" vs. "indices"
+ *  "Pin" is the pin number as would usually be specified by the user in mozziAnalogRead().
+ *  "Channel" is an internal ADC channel number corresponding to that pin. On many platforms this is simply the same as the pin number, on others it differs.
+ *      In other words, this is an internal representation of "pin".
+ *  "Index" is the index of the reading for a certain pin/channel in the array of analog_readings, ranging from 0 to NUM_ANALOG_PINS. This, again may be the
+ *      same as "channel" (e.g. on AVR), however, on platforms where ADC-capable "channels" are not numbered sequentially starting from 0, the channel needs
+ *      to be converted to a suitable index.
+ *
+ *  In summary, the semantics are roughly
+ *      mozziAnalogRead(pin) -> _ADCimplementation_(channel) -> analog_readings[index]
+ *  Implement adcPinToChannelNum() and channelNumToIndex() to perform the appropriate mapping.
+ */
+// NOTE: Theoretically, adcPinToChannelNum is public API for historical reasons, thus cannot be replaced by a define
+#define channelNumToIndex(channel) channel
+uint8_t adcPinToChannelNum(uint8_t pin) {
+  return pin;
+}
+
+/** NOTE: Code needed to trigger a conversion on a new channel */
+void adcStartConversion(uint8_t channel) {
+#warning Fast analog read not implemented on this platform
+}
+
+/** NOTE: Code needed to trigger a subsequent conversion on the latest channel. If your platform has no special code for it, you should store the channel from
+ *  adcStartConversion(), and simply call adcStartConversion(previous_channel), here. */
+void startSecondADCReadOnCurrentChannel() {
+#warning Fast analog read not implemented on this platform
+}
+
+/** NOTE: Code needed to set up faster than usual analog reads, e.g. specifying the number of CPU cycles that the ADC waits for the result to stabilize.
+ *  This particular function is not super important, so may be ok to leave empty, at least, if the ADC is fast enough by default. */
+void setupFastAnalogRead(int8_t speed) {
+#warning Fast analog read not implemented on this platform
+}
+
+/** NOTE: Code needed to initialize the ADC for asynchronous reads. Typically involves setting up an interrupt handler for when conversion is done, and
+ *  possibly calibration. */
+void setupMozziADC(int8_t speed) {
+#warning Fast analog read not implemented on this platform
+}
+
+/* NOTE: Most platforms call a specific function/ISR when conversion is complete. Provide this function, here.
+ * From inside its body, simply call advanceADCStep(). E.g.:
+void stm32_adc_eoc_handler() {
+  advanceADCStep();
+}
+*/
+////// END analog input code ////////
+
+////// BEGIN audio output code //////
+/* NOTE: Some platforms rely on control returning from loop() every so often. However, updateAudio() may take too long (it tries to completely fill the output buffer,
+ * which of course is being drained at the same time, theoretically it may not return at all). If you set this define, it will be called once per audio frame to keep things
+ * running smoothly. */
+//#define LOOP_YIELD yield();
+
+#if (EXTERNAL_AUDIO_OUTPUT != true) // otherwise, the last stage - audioOutput() - will be provided by the user
+#if MBED_AUDIO_OUT_MODE == INTERNAL_DAC
+#include <Arduino_AdvancedAnalog.h>
+AdvancedDAC dac1(AUDIO_CHANNEL_1_PIN);
+AdvancedDAC dac2(AUDIO_CHANNEL_2_PIN);
+DMABuffer<Sample> dummy;
+SampleBuffer buf1(dummy);
+SampleBuffer buf2(dummy);
+int bufpos;
+
+#define CHUNKSIZE 16
+
+/** NOTE: This is the function that actually write a sample to the output. In case of EXTERNAL_AUDIO_OUTPUT == true, it is provided by the library user, instead. */
+inline void audioOutput(const AudioOutput f) {
+  if (bufpos >= CHUNKSIZE) {
+    dac1.write(buf1);
+    dac2.write(buf2);
+    buf1 = dac1.dequeue();
+    buf2 = dac2.dequeue();
+    bufpos = 0;
+  }
+  buf1.data()[bufpos] = f.l()+AUDIO_BIAS;
+  buf2.data()[bufpos] = f.r()+AUDIO_BIAS;
+  ++bufpos;
+#if (AUDIO_CHANNELS > 1)
+  // e.g. analogWrite(AUDIO_CHANNEL_2_PIN, f.r()+AUDIO_BIAS);
+#endif
+}
+
+bool canBufferAudioOutput() {
+  return dac1.available();
+}
+
+static void startAudio() {
+  bufpos = CHUNKSIZE;  // As buffers are initially invalid
+  dac1.begin(AN_RESOLUTION_12, AUDIO_RATE, CHUNKSIZE, 256/CHUNKSIZE);
+  dac2.begin(AN_RESOLUTION_12, AUDIO_RATE, CHUNKSIZE, 256/CHUNKSIZE);
+
+  // Add here code to get audio output going. This usually involves:
+  // 1) setting up some DAC mechanism (e.g. setting up a PWM pin with appropriate resolution
+  // 2a) setting up a timer to call defaultAudioOutput() at AUDIO_RATE
+  // OR 2b) setting up a buffered output queue such as I2S (see ESP32 / ESP8266 for examples for this setup)
+
+  // remember that the user may configure EXTERNAL_AUDIO_OUTPUT, in which case, you'll want to provide step 2a), and only that.
+}
+
+void stopMozzi() {
+  // Add here code to pause whatever mechanism moves audio samples to the output
+}
+#endif
+#endif
+////// END audio output code //////

--- a/MozziGuts_impl_MBED.hpp
+++ b/MozziGuts_impl_MBED.hpp
@@ -102,7 +102,7 @@ void stm32_adc_eoc_handler() {
 #if (EXTERNAL_AUDIO_OUTPUT != true && MBED_AUDIO_OUT_MODE == INTERNAL_DAC) // otherwise, the last stage - audioOutput() - will be provided by the user
 #include <Arduino_AdvancedAnalog.h>
 
-#define CHUNKSIZE 256  // Smaller ought to be possible, but currently affected by https://github.com/arduino-libraries/Arduino_AdvancedAnalog/issues/35
+#define CHUNKSIZE 64
 AdvancedDAC dac1(AUDIO_CHANNEL_1_PIN);
 Sample buf1[CHUNKSIZE];
 #if (AUDIO_CHANNELS > 1)
@@ -139,14 +139,13 @@ bool canBufferAudioOutput() {
 }
 
 static void startAudio() {
-  //NOTE: AdvancedDAC seems suspiciously dependent on a specific size and number of buffers, in order to work without hickups. Both too few, and too many cause problems.
-  //      Revisit setup after https://github.com/arduino-libraries/Arduino_AdvancedAnalog/issues/35 is resolved
-  if (!dac1.begin(AN_RESOLUTION_12, AUDIO_RATE, CHUNKSIZE, 2048/CHUNKSIZE)) {
+  //NOTE: DAC setup currently affected by https://github.com/arduino-libraries/Arduino_AdvancedAnalog/issues/35 . Don't expect this to work, until using a fixed version fo Arduino_AdvancedAnalog!
+  if (!dac1.begin(AN_RESOLUTION_12, AUDIO_RATE, CHUNKSIZE, 256/CHUNKSIZE)) {
       Serial.println("Failed to start DAC1 !");
       while (1);
   }
 #if (AUDIO_CHANNELS > 1)
-  if (!dac2.begin(AN_RESOLUTION_12, AUDIO_RATE, CHUNKSIZE, 2048/CHUNKSIZE)) {
+  if (!dac2.begin(AN_RESOLUTION_12, AUDIO_RATE, CHUNKSIZE, 256/CHUNKSIZE)) {
       Serial.println("Failed to start DAC2 !");
       while (1);
   }

--- a/MozziGuts_impl_template.hpp
+++ b/MozziGuts_impl_template.hpp
@@ -104,6 +104,12 @@ void stm32_adc_eoc_handler() {
  * running smoothly. */
 //#define LOOP_YIELD yield();
 
+/* NOTE: On some platforms, what can be called in the ISR used to output the sound is limited.
+ * This define can be used, for instance, to output the sound in audioHook() instead to overcome
+ * this limitation (see MozziGuts_impl_MBED.hpp). It can also be used if something needs to be called in audioHook() regarding
+ * analog reads for instance. */
+//#define AUDIO_HOOK_HOOK
+
 #if (EXTERNAL_AUDIO_OUTPUT != true) // otherwise, the last stage - audioOutput() - will be provided by the user
 /** NOTE: This is the function that actually write a sample to the output. In case of EXTERNAL_AUDIO_OUTPUT == true, it is provided by the library user, instead. */
 inline void audioOutput(const AudioOutput f) {

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Arduino Nano | 9 | yes
 Arduino Pro Mini | 9 | yes
 Arduino Leonardo | 9 | yes
 Arduino Mega | 11 | yes
+Arduino Giga | A13 (jack) | yes
 Freetronics EtherMega | 11 | yes
 Ardweeny | 9 | yes     
 Boarduino | 9 | yes
@@ -302,6 +303,18 @@ on the RP2040 SDK API. Tested on a Pi Pico.
 - twi_nonblock is not ported
 - Code uses only one CPU core
 
+### Arduino Giga
+port by Thomas Friedrichsmeier
+
+Compiles and runs using Arduino's standard and Arduino_AdvancedAnalog libraries.
+
+- This port is not complete yet, in particular:
+  - AUDIO_INPUT is not implemented (yet).
+  - Asynchroneous analog reads are not implemented (yet), `mozziAnalogRead()` relays to `analogRead()`.
+  - HIFI mode is not implemented.
+- In addition to using an user-defined `audioOutput()` by setting `EXTERNAL_AUDIO_OUTPUT` to `true` in mozzi_config.h, two bare chip output modes exist (configurable in AudioConfigMBED.h):
+  - INTERNAL_DAC: uses the DAC present on the board and outputs by default on pin A13 (3.5mm jack connector's tip). Stereo mode uses pin A12 (3.5mm jack connector's first ring) additionnaly.
+  - PDM_VIA_SERIAL: returns a pulse-density modulated signal on one of the hardware UART of the board (Serial ports). Default is using the SERIAL2, on pin D18.
 
 ***
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Arduino Nano | 9 | yes
 Arduino Pro Mini | 9 | yes
 Arduino Leonardo | 9 | yes
 Arduino Mega | 11 | yes
+Arduino MBED (only the Giga has been tested, see "Hardware specific notes", below) | A13 | no
 Arduino Giga | A13 (jack) | yes
 Freetronics EtherMega | 11 | yes
 Ardweeny | 9 | yes     
@@ -311,7 +312,7 @@ on the RP2040 SDK API. Tested on a Pi Pico.
 - twi_nonblock is not ported
 - Code uses only one CPU core
 
-### Arduino Giga
+### Arduino Giga/MBED
 port by Thomas Friedrichsmeier & Thomas Combriat
 
 Compiles and runs using Arduino's standard and Arduino_AdvancedAnalog libraries.
@@ -323,6 +324,7 @@ Compiles and runs using Arduino's standard and Arduino_AdvancedAnalog libraries.
 - In addition to using an user-defined `audioOutput()` by setting `EXTERNAL_AUDIO_OUTPUT` to `true` in mozzi_config.h, two bare chip output modes exist (configurable in AudioConfigMBED.h):
   - INTERNAL_DAC: uses the DAC present on the board and outputs by default on pin A13 (3.5mm jack connector's tip). Stereo mode uses pin A12 (3.5mm jack connector's first ring) additionally.
   - PDM_VIA_SERIAL: returns a pulse-density modulated signal on one of the hardware UART of the board (Serial ports). Default is using the SERIAL2, on pin D18.
+- This port should support other MBED based Arduino boards like the Arduino Portenta, in *theory*. It has only been tested on the giga but feedbacks are welcome!
 
 ***
 

--- a/extras/NEWS.txt
+++ b/extras/NEWS.txt
@@ -4,7 +4,7 @@ NEWS
 get the latest version from https://sensorium.github.io/Mozzi/
 
 release v1.1.0
--new synth classes (and examples) by Tom Combriat @tomcombriat:
+- new synth classes (and examples) by Tom Combriat @tomcombriat:
 	- Wavefolder
 	- MetaOscil
 	- MultiResonantFilter
@@ -12,9 +12,11 @@ release v1.1.0
 
 release v1.1.0rc1 (not actually "released", just the Github code around 2019 onwards.)
 - Initial RP2040 port added by Thomas Friedrichsmeier
+	Hardware specific notes are on the Mozzi main web page.
+- Initial Teensy 4.X port added by Tom Combriat
 - Code reorganised to split most hardware specific code into dedicated files
 - STEREO_HACK is deprecated in favor of AUDIO_CHANNELS
-- updateAudio() should be slightly rewritten for portability across different configuraitions and boards
+- updateAudio() should be slightly rewritten for portability across different configurations and boards
 	- refer to the MonoOutput() and StereoOutput() classes for more detail
 - EXTERNAL_AUDIO_OUPUT allows to integrate external DACs, easily
 - STM32(duino) and ESP8266 ports have been added by Thomas Friedrichsmeier, ESP32 port by Dieter Vandoren and Thomas Friedrichsmeier.

--- a/extras/NEWS.txt
+++ b/extras/NEWS.txt
@@ -3,8 +3,12 @@ Mozzi sound synthesis library for Arduino
 NEWS
 get the latest version from https://sensorium.github.io/Mozzi/
 
+release v1.1.0
+-new synth classes (and examples) by Tom Combriat @tomcombriat:
+	- Wavefolder
+	- MetaOscil
+	- MultiResonantFilter
 
-Mozzi is now available as the most recent code on Github, rather than as releases.
 
 release v1.1.0rc1 (not actually "released", just the Github code around 2019 onwards.)
 - Initial RP2040 port added by Thomas Friedrichsmeier

--- a/extras/NEWS.txt
+++ b/extras/NEWS.txt
@@ -3,6 +3,9 @@ Mozzi sound synthesis library for Arduino
 NEWS
 get the latest version from https://sensorium.github.io/Mozzi/
 
+not yet released (latest github version)
+- new partial port of the Arduino Giga by Thomas Friedrichsmeier
+
 release v1.1.0
 - new synth classes (and examples) by Tom Combriat @tomcombriat:
 	- Wavefolder

--- a/hardware_defines.h
+++ b/hardware_defines.h
@@ -16,12 +16,14 @@
 #define IS_SAMD21() (defined(ARDUINO_ARCH_SAMD))
 #define IS_TEENSY3() (defined(__MK20DX128__) || defined(__MK20DX256__) || defined(__MK64FX512__) || defined(__MK66FX1M0__) || defined(__MKL26Z64__))  // 32bit arm-based Teensy
 #define IS_TEENSY4() (defined(__IMXRT1062__)) // Teensy4 (no DAC)
-#define IS_STM32() (defined(__arm__) && !IS_TEENSY3() && !IS_SAMD21() && !IS_TEENSY4() && !IS_RP2040())  // STM32 boards (note that only the maple based core is supported at this time. If another cores is to be supported in the future, this define should be split.
+#define IS_MBED() (defined(ARDUINO_ARCH_MBED))
+#define IS_STM32() (defined(__arm__) && !IS_TEENSY3() && !IS_SAMD21() && !IS_TEENSY4() && !IS_RP2040() && !IS_MBED())  // STM32 boards (note that only the maple based core is supported at this time. If another cores is to be supported in the future, this define should be split.
 #define IS_ESP8266() (defined(ESP8266))
 #define IS_ESP32() (defined(ESP32))
 #define IS_RP2040() (defined(ARDUINO_ARCH_RP2040))
+#define IS_GIGA() (IS_MBED() && defined(ARDUINO_GIGA))
 
-#if !(IS_AVR() || IS_TEENSY3() || IS_TEENSY4() || IS_STM32() || IS_ESP8266() || IS_SAMD21() || IS_ESP32() || IS_RP2040())
+#if !(IS_AVR() || IS_TEENSY3() || IS_TEENSY4() || IS_STM32() || IS_ESP8266() || IS_SAMD21() || IS_ESP32() || IS_RP2040() || IS_GIGA())
 #error Your hardware is not supported by Mozzi or not recognized. Edit hardware_defines.h to proceed.
 #endif
 

--- a/hardware_defines.h
+++ b/hardware_defines.h
@@ -80,7 +80,7 @@
 #define IS_ESP32() 0
 #endif
 
-#if !(IS_AVR() || IS_TEENSY3() || IS_TEENSY4() || IS_STM32() || IS_ESP8266() || IS_SAMD21() || IS_ESP32() || IS_RP2040() || IS_GIGA())
+#if !(IS_AVR() || IS_TEENSY3() || IS_TEENSY4() || IS_STM32() || IS_ESP8266() || IS_SAMD21() || IS_ESP32() || IS_RP2040() || IS_MBED())
 #error Your hardware is not supported by Mozzi or not recognized. Edit hardware_defines.h to proceed.
 #endif
 


### PR DESCRIPTION
Initial port of Arduino Giga, essentially made by @tfry-git .

I have checked that both output modes (and external audio output) work fine and added some initial documentation.
I have also inverted the default pins for outputting on the DAC so that mono outputs on the tip of the jack (left) which is the standard.