### PR TITLE
Devel/giga audio input

### DIFF
--- a/AudioConfigMBED.h
+++ b/AudioConfigMBED.h
@@ -39,7 +39,7 @@
 #error Invalid output mode configured in AudioConfigMBED.h
 #endif
 
-#define BYPASS_MOZZI_INPUT_BUFFER true
+//#define BYPASS_MOZZI_INPUT_BUFFER true
 #define AUDIO_BIAS ((uint16_t) 1<<(AUDIO_BITS-1))
 
 #endif        //  #ifndef AUDIOCONFIGMBED_H

--- a/AudioConfigMBED.h
+++ b/AudioConfigMBED.h
@@ -39,6 +39,7 @@
 #error Invalid output mode configured in AudioConfigMBED.h
 #endif
 
+#define BYPASS_MOZZI_INPUT_BUFFER true
 #define AUDIO_BIAS ((uint16_t) 1<<(AUDIO_BITS-1))
 
 #endif        //  #ifndef AUDIOCONFIGMBED_H

--- a/MozziGuts.cpp
+++ b/MozziGuts.cpp
@@ -139,8 +139,10 @@ int mozziAnalogRead(uint8_t pin) {
 }
 
 #if (USE_AUDIO_INPUT == true)
-static int audio_input; // holds the latest audio from input_buffer
-int getAudioInput() { return audio_input; }
+static AudioOutputStorage_t audio_input; // holds the latest audio from input_buffer
+AudioOutputStorage_t getAudioInput() { return audio_input; }
+#endif
+
 //#if (!BYPASS_MOZZI_INPUT_BUFFER)
 #if (AUDIO_INPUT_MODE == AUDIO_INPUT_LEGACY)
 // ring buffer for audio input
@@ -172,11 +174,7 @@ inline void advanceADCStep() {
   }
   adc_count++;
 }
-#endif // #if (AUDIO_INPUT_MODE == AUDIO_INPUT_LEGACY)
-#endif // #if (USE_AUDIO_INPUT == true)
-//#elif (!USE_AUDIO_INPUT || (USE_AUDIO_INPUT && BYPASS_MOZZI_INPUT_BUFFER)) // in case we skipped the previous block, we still need to implement async ADC, just like without audio inputs
-
-#if (AUDIO_INPUT_MODE == AUDIO_INPUT_NONE || AUDIO_INPUT_MODE == AUDIO_INPUT_CUSTOM)  // in case we skipped the previous block, we still need to implement async ADC, just like without audio inputs
+#else
 /** NOTE: Triggered at CONTROL_RATE via advanceControlLoop().
 
 This interrupt handler cycles through all analog inputs on the adc_channels_to_read Stack,
@@ -194,7 +192,7 @@ inline void advanceADCStep() {
     adc_count=0;
   }
 }
-#endif // #if (AUDIO_INPUT_MODE == AUDIO_INPUT_NONE || AUDIO_INPUT_MODE == AUDIO_INPUT_CUSTOM) 
+#endif // else block #if (AUDIO_INPUT_MODE == AUDIO_INPUT_LEGACY)
 
 ////// END analog input code ////////
 

--- a/MozziGuts.cpp
+++ b/MozziGuts.cpp
@@ -196,10 +196,6 @@ inline void advanceControlLoop() {
 void audioHook() // 2us on AVR excluding updateAudio()
 {
 // setPin13High();
-#if (USE_AUDIO_INPUT == true)
-  if (audioInputAvailable()) audio_input = readAudioInput(); 
-#endif
-
   if (canBufferAudioOutput()) {
     advanceControlLoop();
 #if (STEREO_HACK == true)
@@ -211,7 +207,11 @@ void audioHook() // 2us on AVR excluding updateAudio()
 
 #if defined(LOOP_YIELD)
     LOOP_YIELD
-#endif      
+#endif
+
+#if (USE_AUDIO_INPUT == true)
+  if (audioInputAvailable()) audio_input = readAudioInput(); 
+#endif
       }
 // Like LOOP_YIELD, but running every cycle of audioHook(), not just once per sample
 #if defined(AUDIO_HOOK_HOOK)

--- a/MozziGuts.cpp
+++ b/MozziGuts.cpp
@@ -81,7 +81,7 @@ CircularBuffer<AudioOutput_t> output_buffer;  // fixed size 256
 #  define canBufferAudioOutput() (!output_buffer.isFull())
 #  define bufferAudioOutput(f) output_buffer.write(f)
 static void CACHED_FUNCTION_ATTR defaultAudioOutput() {
-  //#  if (USE_AUDIO_INPUT == true && !BYPASS_MOZZI_INPUT_BUFFER == true) // in that case, we rely on asynchroneous ADC reads implemented for mozziAnalogRead to get the audio in samples
+
 #if (AUDIO_INPUT_MODE == AUDIO_INPUT_LEGACY) // in that case, we rely on asynchroneous ADC reads implemented for mozziAnalogRead to get the audio in samples
   adc_count = 0;
   startSecondADCReadOnCurrentChannel();  // the current channel is the AUDIO_INPUT pin
@@ -117,7 +117,6 @@ void adcReadSelectedChannels() {
 __attribute__((noinline)) void adcStartReadCycle() {
 	if (current_channel < 0) // last read of adc_channels_to_read stack was empty, ie. all channels from last time have been read
 	{
-	  //#if (USE_AUDIO_INPUT == true && !BYPASS_MOZZI_INPUT_BUFFER == true) // use of async ADC for audio input
 #if (AUDIO_INPUT_MODE == AUDIO_INPUT_LEGACY) // use of async ADC for audio input
 		adc_channels_to_read.push(AUDIO_INPUT_PIN); // for audio
 #else
@@ -143,7 +142,6 @@ static AudioOutputStorage_t audio_input; // holds the latest audio from input_bu
 AudioOutputStorage_t getAudioInput() { return audio_input; }
 #endif
 
-//#if (!BYPASS_MOZZI_INPUT_BUFFER)
 #if (AUDIO_INPUT_MODE == AUDIO_INPUT_LEGACY)
 // ring buffer for audio input
 CircularBuffer<unsigned int> input_buffer; // fixed size 256
@@ -192,7 +190,7 @@ inline void advanceADCStep() {
     adc_count=0;
   }
 }
-#endif // else block #if (AUDIO_INPUT_MODE == AUDIO_INPUT_LEGACY)
+#endif
 
 ////// END analog input code ////////
 

--- a/MozziGuts.cpp
+++ b/MozziGuts.cpp
@@ -196,10 +196,8 @@ inline void advanceControlLoop() {
 void audioHook() // 2us on AVR excluding updateAudio()
 {
 // setPin13High();
-#if (USE_AUDIO_INPUT == true && !BYPASS_MOZZI_INPUT_BUFFER)
-  if (audioInputAvailable())
-    audio_input = readAudioInput();
-  /* audio_input = input_buffer.read();*/
+#if (USE_AUDIO_INPUT == true)
+  if (audioInputAvailable()) audio_input = readAudioInput(); 
 #endif
 
   if (canBufferAudioOutput()) {

--- a/MozziGuts_impl_MBED.hpp
+++ b/MozziGuts_impl_MBED.hpp
@@ -73,6 +73,13 @@ void stm32_adc_eoc_handler() {
   advanceADCStep();
 }
 */
+
+#if (USE_AUDIO_INPUT)
+#define audioInputAvailable() (true)
+#define readAudioInput() (0)
+
+#endif
+
 ////// END analog input code ////////
 
 ////// BEGIN audio output code //////

--- a/MozziGuts_impl_MBED.hpp
+++ b/MozziGuts_impl_MBED.hpp
@@ -28,23 +28,18 @@ int inbufpos=0;
 
 bool audioInputAvailable()  {
   if (inbufpos >= CHUNKSIZEIN)
-    {
+     {
       if (!adc.available()) return false;
       SampleBuffer buf = adc.read();
-      /*
-      for (unsigned int i = 0; i < CHUNKSIZE; ++i) {
-	inbuf[i] = buf[i];
-	}*/
-      for (int i = 0; i < buf.size(); ++i) memcpy(inbuf,buf.data(), CHUNKSIZEIN*sizeof(Sample));
+      memcpy(inbuf,buf.data(), CHUNKSIZEIN*sizeof(Sample));
       inbufpos = 0;
       buf.release();
       return true;
-    }
+       }
   else return true;
 }
 AudioOutput_t readAudioInput(){
-  inbufpos++;
-  return inbuf[inbufpos-1];
+  return inbuf[inbufpos++];
 }
 
 

--- a/MozziGuts_impl_MBED.hpp
+++ b/MozziGuts_impl_MBED.hpp
@@ -40,7 +40,7 @@ bool audioInputAvailable()  {
        }
   else return true;
 }
-AudioOutput_t readAudioInput(){
+AudioOutputStorage_t readAudioInput(){
   return inbuf[inbufpos++];
 }
 
@@ -177,8 +177,11 @@ inline void audioOutput(const AudioOutput f) {
 }
 
 bool canBufferAudioOutput() {
-  // NOTE: In case of stereo, we *assume* the DACs to be running exactly in sync. However, this is safe enough to do, as AdvancedDAC::dequeue() will wait if necessary.
-  return (bufpos < CHUNKSIZE || dac1.available());
+  return (bufpos < CHUNKSIZE || (dac1.available()
+#if (AUDIO_CHANNELS > 1)
+    && dac2.available()
+#endif
+  ));
 }
 
 static void startAudio() {

--- a/MozziGuts_impl_MBED.hpp
+++ b/MozziGuts_impl_MBED.hpp
@@ -28,16 +28,15 @@ AdvancedADC adc(AUDIO_INPUT_PIN);
 Sample inbuf[CHUNKSIZE];
 int inbufpos=0; 
 
-bool audioInputAvailable()  {
-  if (inbufpos >= CHUNKSIZE)
-     {
-      if (!adc.available()) return false;
-      SampleBuffer buf = adc.read();
-      memcpy(inbuf,buf.data(), CHUNKSIZE*sizeof(Sample));
-      inbufpos = 0;
-      buf.release();
-      return true;
-       }
+bool audioInputAvailable() {
+  if (inbufpos >= CHUNKSIZE) {
+    if (!adc.available()) return false;
+    SampleBuffer buf = adc.read();
+    memcpy(inbuf,buf.data(), CHUNKSIZE*sizeof(Sample));
+    inbufpos = 0;
+    buf.release();
+    return true;
+  }
   else return true;
 }
 AudioOutputStorage_t readAudioInput(){
@@ -45,12 +44,11 @@ AudioOutputStorage_t readAudioInput(){
 }
 
 
-static void startAudioInput()
-{
+static void startAudioInput() {
   if (!adc.begin(AN_RESOLUTION_12, AUDIO_RATE, CHUNKSIZE, 256/CHUNKSIZE)) {
-        Serial.println("Failed to start analog acquisition!");
-        while (1);
-    }
+    Serial.println("Failed to start analog acquisition!");
+    while (1);
+  }
 }
 #endif
 
@@ -187,13 +185,13 @@ bool canBufferAudioOutput() {
 static void startAudio() {
   //NOTE: DAC setup currently affected by https://github.com/arduino-libraries/Arduino_AdvancedAnalog/issues/35 . Don't expect this to work, until using a fixed version fo Arduino_AdvancedAnalog!
   if (!dac1.begin(AN_RESOLUTION_12, AUDIO_RATE, CHUNKSIZE, 256/CHUNKSIZE)) {
-      Serial.println("Failed to start DAC1 !");
-      while (1);
+    Serial.println("Failed to start DAC1 !");
+    while (1);
   }
 #if (AUDIO_CHANNELS > 1)
   if (!dac2.begin(AN_RESOLUTION_12, AUDIO_RATE, CHUNKSIZE, 256/CHUNKSIZE)) {
-      Serial.println("Failed to start DAC2 !");
-      while (1);
+    Serial.println("Failed to start DAC2 !");
+    while (1);
   }
 #endif
 }

--- a/MozziGuts_impl_MBED.hpp
+++ b/MozziGuts_impl_MBED.hpp
@@ -23,7 +23,6 @@
 
 #include <Arduino_AdvancedAnalog.h>
 
-#define CHUNKSIZE 64
 AdvancedADC adc(AUDIO_INPUT_PIN);
 Sample inbuf[CHUNKSIZE];
 int inbufpos=0; 
@@ -153,8 +152,8 @@ int bufpos = 0;
 
 inline void commitBuffer(Sample buffer[], AdvancedDAC &dac) {
   SampleBuffer dmabuf = dac.dequeue();
+  // NOTE: Yes, this is silly code, and originated as an accident. Somehow it appears to help _a little_ against current problem wrt DAC stability
   for (unsigned int i=0;i<CHUNKSIZE;i++) memcpy(dmabuf.data(), buffer, CHUNKSIZE*sizeof(Sample));
-  //for (unsigned int i=0;i<CHUNKSIZE;i++) dmabuf[i]=buffer[i];
   dac.write(dmabuf);
 }
 

--- a/README.md
+++ b/README.md
@@ -315,10 +315,9 @@ on the RP2040 SDK API. Tested on a Pi Pico.
 ### Arduino Giga/MBED
 port by Thomas Friedrichsmeier & Thomas Combriat
 
-Compiles and runs using Arduino's standard and Arduino_AdvancedAnalog libraries.
+Compiles and runs using Arduino's standard and Arduino_AdvancedAnalog libraries. This port is still **experimental**, testing reveals some instabilities for some configurations (in particular with USE_AUDIO_INPUT) that are under active investigations.
 
 - This port is not complete yet, in particular:
-  - AUDIO_INPUT is not implemented (yet).
   - Asynchroneous analog reads are not implemented (yet), `mozziAnalogRead()` relays to `analogRead()`.
   - HIFI mode is not implemented.
 - In addition to using an user-defined `audioOutput()` by setting `EXTERNAL_AUDIO_OUTPUT` to `true` in mozzi_config.h, two bare chip output modes exist (configurable in AudioConfigMBED.h):


### PR DESCRIPTION
Hi!
This is an initial trial in making audio input working on the giga. It is actually a bit more as, because of the way ADCs work on MBED, it is possible to skip completely the input_buffer. Basically, I tried to "modularize" more the AUDIO_INPUT feature, allowing to work on a Mozzi buffer or on an hardware implemented one. In the end it is becoming very symmetric to what is implemented for *outputting* audio which I personally find very satisfying. Note that this would probably ease the implementation of other ways of inputting audio with timed protocols (I'm thinking of I2S, which can be used for both input and output). This actually should probably have been the subject of a separate PR… I am happy to get suggestions on that!

But,

This does not work well on the giga yet. The sampling rate seems to be way off (from the scope, seems to be around 1kHz). I guess the problem comes from a wrong use of DMA in the implementation, but my brain is too fried now to investigate it further today. I tried to mimic the dac output that @tfry-git implemented, but opposite, but it is still not satisfying. I hope that he might have an illumination on that…

Note that I did not test (yet) if the modularization broke the INPUT_AUDIO using Mozzi buffers. For this reason, and basically because it is not working yet, I am putting this PR as draft.