### PR TITLE
Fixed compilation for EXTERNAL_AUDIO_OUTPUT for "new" STM32duino

### DIFF
--- a/AudioConfigSTM32duino.h
+++ b/AudioConfigSTM32duino.h
@@ -7,6 +7,8 @@
 
 // Audio output pin. If you want to change this, make sure to also set AUDIO_PWM_TIMER to whichever timer is responsible for your PWM pin, and set the other timers to non-conflicting values
 #define AUDIO_CHANNEL_1_PIN PA8  // Note: PB8 does not appear to be available as a PWM pin with this core.
+// The timer used for running the audio update loop. This must _not_ be the same timer responsible for PWM on the output pins! NOTE: Timer 3 appears to clash with SPI DMA transfers under some circumstances
+#define AUDIO_UPDATE_TIMER TIM2
 
 #if (AUDIO_MODE == HIFI)
 // Second out pin for HIFI mode. This must be on the same timer as AUDIO_CHANNEL_1_PIN!

--- a/AudioConfigSTM32duino.h
+++ b/AudioConfigSTM32duino.h
@@ -7,8 +7,6 @@
 
 // Audio output pin. If you want to change this, make sure to also set AUDIO_PWM_TIMER to whichever timer is responsible for your PWM pin, and set the other timers to non-conflicting values
 #define AUDIO_CHANNEL_1_PIN PA8  // Note: PB8 does not appear to be available as a PWM pin with this core.
-// The timer used for running the audio update loop. This must _not_ be the same timer responsible for PWM on the output pins! NOTE: Timer 3 appears to clash with SPI DMA transfers under some circumstances
-#define AUDIO_UPDATE_TIMER TIM2
 
 #if (AUDIO_MODE == HIFI)
 // Second out pin for HIFI mode. This must be on the same timer as AUDIO_CHANNEL_1_PIN!

--- a/MozziGuts_impl_STM32duino.hpp
+++ b/MozziGuts_impl_STM32duino.hpp
@@ -83,12 +83,10 @@ void checkADCConversionComplete() {
 
 
 //// BEGIN AUDIO OUTPUT code ///////
-// The timer used for running the audio update loop. This must _not_ be the same timer responsible for PWM on the output pins! NOTE: Timer 3 appears to clash with SPI DMA transfers under some circumstances
-#define AUDIO_UPDATE_TIMER TIM2
-
+#if (EXTERNAL_AUDIO_OUTPUT == true)
+HardwareTimer audio_update_timer(2);
+#else
 HardwareTimer audio_update_timer(AUDIO_UPDATE_TIMER);
-
-#if (EXTERNAL_AUDIO_OUTPUT != true)
 HardwareTimer *pwm_timer_ht;
 PinName output_pin_1 = digitalPinToPinName(AUDIO_CHANNEL_1_PIN);
 uint32_t pwm_timer_channel_1 = STM_PIN_CHANNEL(pinmap_function(output_pin_1, PinMap_TIM));

--- a/MozziGuts_impl_STM32duino.hpp
+++ b/MozziGuts_impl_STM32duino.hpp
@@ -83,6 +83,9 @@ void checkADCConversionComplete() {
 
 
 //// BEGIN AUDIO OUTPUT code ///////
+// The timer used for running the audio update loop. This must _not_ be the same timer responsible for PWM on the output pins! NOTE: Timer 3 appears to clash with SPI DMA transfers under some circumstances
+#define AUDIO_UPDATE_TIMER TIM2
+
 HardwareTimer audio_update_timer(AUDIO_UPDATE_TIMER);
 
 #if (EXTERNAL_AUDIO_OUTPUT != true)


### PR DESCRIPTION
Hi!
This fixes the compilation the EXTERNAL_AUDIO_OUTPUT feature for the new the STM port.

Note sure where is the best place to put this declaration though…

