### PR TITLE
Asynchroneous ADC (mozziAnalogRead) for Uno R4

### DIFF
--- a/MozziGuts_impl_RENESAS.hpp
+++ b/MozziGuts_impl_RENESAS.hpp
@@ -20,11 +20,11 @@
 ////// BEGIN analog input code ////////
 
 
-#define channelNumToIndex(channel) channel-14
-void const *const p_context = 0;
-adc_callback_args_t *const p_callback_memory = NULL;
-uint16_t cfg_adc = 0;
-uint8_t r4_pin;
+#define channelNumToIndex(channel) channel-14  // A0=14
+void const *const p_context = 0; // unused but needed for the ADC call
+adc_callback_args_t *const p_callback_memory = NULL;  // idem
+uint16_t cfg_adc = 0;  // put at 0 for starters but modified by the ADC_container
+uint8_t r4_pin; // to store it between calls
 
 void adc_callback(adc_callback_args_t *p_args) {
   advanceADCStep();
@@ -40,37 +40,22 @@ uint8_t adcPinToChannelNum(uint8_t pin) {
   return pin;
 }
 
-/** NOTE: Code needed to trigger a conversion on a new channel */
 void adcStartConversion(uint8_t channel) {
   r4_pin = channel;  // remember for startSecondADCReadOnCurrentChannel()
   startScan(r4_pin);
 }
 
-/** NOTE: Code needed to trigger a subsequent conversion on the latest channel. If your platform has no special code for it, you should store the channel from
- *  adcStartConversion(), and simply call adcStartConversion(previous_channel), here. */
 void startSecondADCReadOnCurrentChannel() {
   startScan(r4_pin);
 }
 
-/** NOTE: Code needed to set up faster than usual analog reads, e.g. specifying the number of CPU cycles that the ADC waits for the result to stabilize.
- *  This particular function is not super important, so may be ok to leave empty, at least, if the ADC is fast enough by default. */
 void setupFastAnalogRead(int8_t speed) {
   //#warning Fast analog read not implemented on this platform
 }
 
-/** NOTE: Code needed to initialize the ADC for asynchronous reads. Typically involves setting up an interrupt handler for when conversion is done, and
- *  possibly calibration. */
 void setupMozziADC(int8_t speed) {
   IRQManager::getInstance().addADCScanEnd(&adc, NULL);
 }
-
-/* NOTE: Most platforms call a specific function/ISR when conversion is complete. Provide this function , here.
- * From inside its body, simply call advanceADCStep(). E.g.:
- void stm32_adc_eoc_handler() {
- advanceADCStep();
- }
-*/
-
 
   
 ////// END analog input code ////////

--- a/MozziGuts_impl_RENESAS.hpp
+++ b/MozziGuts_impl_RENESAS.hpp
@@ -19,45 +19,60 @@
 
 ////// BEGIN analog input code ////////
 
-//#define MOZZI_FAST_ANALOG_IMPLEMENTED
 
-#define getADCReading() 0
+#define channelNumToIndex(channel) channel-14
+void const *const p_context = 0;
+adc_callback_args_t *const p_callback_memory = NULL;
+uint16_t cfg_adc = 0;
+uint8_t r4_pin;
 
+void adc_callback(adc_callback_args_t *p_args) {
+  advanceADCStep();
+}
 
-#define channelNumToIndex(channel) channel
+#include "MozziGuts_impl_RENESAS_ADC.hpp"
+
+#define MOZZI_FAST_ANALOG_IMPLEMENTED
+
+#define getADCReading() readADC(r4_pin)
+
 uint8_t adcPinToChannelNum(uint8_t pin) {
   return pin;
 }
 
 /** NOTE: Code needed to trigger a conversion on a new channel */
 void adcStartConversion(uint8_t channel) {
-#warning Fast analog read not implemented on this platform
+  r4_pin = channel;  // remember for startSecondADCReadOnCurrentChannel()
+  startScan(r4_pin);
 }
 
 /** NOTE: Code needed to trigger a subsequent conversion on the latest channel. If your platform has no special code for it, you should store the channel from
  *  adcStartConversion(), and simply call adcStartConversion(previous_channel), here. */
 void startSecondADCReadOnCurrentChannel() {
-#warning Fast analog read not implemented on this platform
+  startScan(r4_pin);
 }
 
 /** NOTE: Code needed to set up faster than usual analog reads, e.g. specifying the number of CPU cycles that the ADC waits for the result to stabilize.
  *  This particular function is not super important, so may be ok to leave empty, at least, if the ADC is fast enough by default. */
 void setupFastAnalogRead(int8_t speed) {
-#warning Fast analog read not implemented on this platform
+  //#warning Fast analog read not implemented on this platform
 }
 
 /** NOTE: Code needed to initialize the ADC for asynchronous reads. Typically involves setting up an interrupt handler for when conversion is done, and
  *  possibly calibration. */
 void setupMozziADC(int8_t speed) {
-#warning Fast analog read not implemented on this platform
+  IRQManager::getInstance().addADCScanEnd(&adc, NULL);
 }
 
-/* NOTE: Most platforms call a specific function/ISR when conversion is complete. Provide this function, here.
+/* NOTE: Most platforms call a specific function/ISR when conversion is complete. Provide this function , here.
  * From inside its body, simply call advanceADCStep(). E.g.:
  void stm32_adc_eoc_handler() {
  advanceADCStep();
  }
 */
+
+
+  
 ////// END analog input code ////////
 
 

--- a/MozziGuts_impl_RENESAS.hpp
+++ b/MozziGuts_impl_RENESAS.hpp
@@ -54,7 +54,7 @@ void setupFastAnalogRead(int8_t speed) {
 }
 
 void setupMozziADC(int8_t speed) {
-  IRQManager::getInstance().addADCScanEnd(&adc, NULL);
+  IRQManager::getInstance().addADCScanEnd(&adc, NULL); // this is needed to change some config inside the ADC, even though we do not give the callback here (doing so crashes the board). The callback is declared to the ADC by: R_ADC_CallbackSet(&(_adc->ctrl), adc_callback, p_context, p_callback_memory); in MozziGuts_impl_RENESAS_ADC.hpp.
 }
 
   

--- a/MozziGuts_impl_RENESAS_ADC.hpp
+++ b/MozziGuts_impl_RENESAS_ADC.hpp
@@ -17,7 +17,6 @@ void startScan(int pin)
 {
   int32_t adc_idx = digitalPinToAnalogPin(pin);
   ADC_Container *_adc = get_ADC_container_ptr(adc_idx, cfg_adc);
-  //ADC_Container * _adc = &adc;
   _adc->cfg.mode = ADC_MODE_SINGLE_SCAN;
   pinPeripheral(digitalPinToBspPin(adc_idx), (uint32_t)IOPORT_CFG_ANALOG_ENABLE);
   _adc->channel_cfg.scan_mask |= (1 << GET_CHANNEL(cfg_adc));

--- a/MozziGuts_impl_RENESAS_ADC.hpp
+++ b/MozziGuts_impl_RENESAS_ADC.hpp
@@ -1,0 +1,37 @@
+/*
+
+Parts of this file are drawn from Arduino's source code for analogRead() (https://github.com/arduino/ArduinoCore-renesas/blob/main/cores/arduino/analog.cpp) and part from Renesas' documentation (https://renesas.github.io/fsp/group___a_d_c.html), among other things.
+It contains functions to interact with the ADC in order to implement async ADC reads, aka mozziAnalogRead().
+*/
+
+#include <analog.h>
+#include <analog.cpp>
+#include <IRQManager.h>
+
+
+
+
+//////////////////// ADC //////////////
+
+void startScan(int pin)
+{
+  int32_t adc_idx = digitalPinToAnalogPin(pin);
+  ADC_Container *_adc = get_ADC_container_ptr(adc_idx, cfg_adc);
+  //ADC_Container * _adc = &adc;
+  _adc->cfg.mode = ADC_MODE_SINGLE_SCAN;
+  pinPeripheral(digitalPinToBspPin(adc_idx), (uint32_t)IOPORT_CFG_ANALOG_ENABLE);
+  _adc->channel_cfg.scan_mask |= (1 << GET_CHANNEL(cfg_adc));
+  R_ADC_Open(&(_adc->ctrl), &(_adc->cfg));
+  R_ADC_CallbackSet(&(_adc->ctrl), adc_callback, p_context, p_callback_memory);
+  R_ADC_ScanCfg(&(_adc->ctrl), &(_adc->channel_cfg));
+  R_ADC_ScanStart(&(_adc->ctrl));
+}
+
+uint16_t readADC(int pin)
+{
+  uint16_t result;
+  int32_t adc_idx = digitalPinToAnalogPin(pin);
+  ADC_Container *_adc = get_ADC_container_ptr(adc_idx, cfg_adc);
+  R_ADC_Read(&(_adc->ctrl), (adc_channel_t)GET_CHANNEL(cfg_adc), &result);
+  return result;
+}

--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ Compiles and runs using Arduino's standard library (Renesas 0.8.7 at the time of
 - A few particularities:
   - Because this board has an on-board DAC (A0), but only one, STEREO is not implemented and Mozzi uses this pin. Usage of other pins using PWM for instance is not implemented yet.
   - Two timers are claimed by Mozzi when using the on-board DAC, one when using `EXTERNAL_AUDIO_OUTPUT`.
-  - `mozziAnalogRead()` is not yet implemented and falls back on Arduino's `analogRead()`.
+  - `mozziAnalogRead()` returns values in the Renesas' full ADC resolution of 0-16384 rather than AVR's 0-1023. *This might change in the near future for speed purposes.*
   
 
 ***


### PR DESCRIPTION
Hi!

This is a proposal for implementing `mozziAnalogRead()` on the Uno R4, following #190.
The result is a bit of a jigsaw puzzle between different source code I could find online (from Arduino, and from Renesas)… There are not a lot of documentation on this chip yet, not to say well documented for people green behind the ears like me…

Anyway, this seems to work quite well. I put the sources inside a separate file because they are not fancy to read but when I look at the final result it might be able to go inside the implementation file. I am up for opinions on this but also on the code in general. I might be doing things a bit naively in there but I had a bit of troubles to make that works in the first place.

I think that when this gets in there it might be time for a new release for the two newer ports (giga and R4). I do not mind trying to do it!

Cheers,
