### PR TITLE
Fix frequency offset for AVR

### DIFF
--- a/MozziGuts_impl_AVR.hpp
+++ b/MozziGuts_impl_AVR.hpp
@@ -168,7 +168,7 @@ static uint8_t mozzi_TCCR4A, mozzi_TCCR4B, mozzi_TCCR4C, mozzi_TCCR4D,
 static void startAudio() {
   backupPreMozziTimer1();
   Timer1.initializeCPUCycles(
-      F_CPU / AUDIO_RATE,
+      F_CPU / AUDIO_RATE-1,
       PHASE_FREQ_CORRECT); // set period, phase and frequency correct
   TIMSK1 = _BV(TOIE1); // Overflow Interrupt Enable (when not using
                        // Timer1.attachInterrupt())
@@ -198,10 +198,10 @@ static void startAudio() {
   //	pinMode(AUDIO_CHANNEL_2_PIN, OUTPUT);	// set pin to output for audio
 #  if (AUDIO_MODE == STANDARD)
   Timer1.initializeCPUCycles(
-      F_CPU / AUDIO_RATE,
+      F_CPU / AUDIO_RATE-1,
       PHASE_FREQ_CORRECT); // set period, phase and frequency correct
 #  else // (AUDIO_MODE == STANDARD_PLUS)
-  Timer1.initializeCPUCycles(F_CPU / PWM_RATE,
+  Timer1.initializeCPUCycles(F_CPU / PWM_RATE-1,
                              FAST); // fast mode enables higher PWM rate
 #  endif
   Timer1.pwm(AUDIO_CHANNEL_1_PIN,

--- a/MozziGuts_impl_AVR.hpp
+++ b/MozziGuts_impl_AVR.hpp
@@ -168,7 +168,10 @@ static uint8_t mozzi_TCCR4A, mozzi_TCCR4B, mozzi_TCCR4C, mozzi_TCCR4D,
 static void startAudio() {
   backupPreMozziTimer1();
   Timer1.initializeCPUCycles(
-      F_CPU / AUDIO_RATE-1,
+      (F_CPU/AUDIO_RATE)-1 // the -1 here is a result of empirical tests
+                           // that showed that it brings the resulting frequency
+                           // closer to what is expected.
+                           // see: https://github.com/sensorium/Mozzi/pull/202
       PHASE_FREQ_CORRECT); // set period, phase and frequency correct
   TIMSK1 = _BV(TOIE1); // Overflow Interrupt Enable (when not using
                        // Timer1.attachInterrupt())
@@ -198,10 +201,16 @@ static void startAudio() {
   //	pinMode(AUDIO_CHANNEL_2_PIN, OUTPUT);	// set pin to output for audio
 #  if (AUDIO_MODE == STANDARD)
   Timer1.initializeCPUCycles(
-      F_CPU / AUDIO_RATE-1,
+      (F_CPU/AUDIO_RATE)-1,// the -1 here is a result of empirical tests
+                           // that showed that it brings the resulting frequency
+                           // closer to what is expected.
+                           // see: https://github.com/sensorium/Mozzi/pull/202
       PHASE_FREQ_CORRECT); // set period, phase and frequency correct
 #  else // (AUDIO_MODE == STANDARD_PLUS)
-  Timer1.initializeCPUCycles(F_CPU / PWM_RATE-1,
+  Timer1.initializeCPUCycles((F_CPU/PWM_RATE)-1, // the -1 here is a result of empirical tests
+                                                 // that showed that it brings the resulting frequency
+                                                 // closer to what is expected.
+                                                 // see: https://github.com/sensorium/Mozzi/pull/202
                              FAST); // fast mode enables higher PWM rate
 #  endif
   Timer1.pwm(AUDIO_CHANNEL_1_PIN,
@@ -267,7 +276,7 @@ static void startAudio() {
   pinMode(AUDIO_CHANNEL_1_lowByte_PIN,
           OUTPUT); // set pin to output for audio, use 499k resistor
   Timer1.initializeCPUCycles(
-      F_CPU / 125000,
+      F_CPU/125000,
       FAST); // set period for 125000 Hz fast pwm carrier frequency = 14 bits
   Timer1.pwm(AUDIO_CHANNEL_1_highByte_PIN,
              0); // pwm pin, 0% duty cycle, ie. 0 signal


### PR DESCRIPTION
Hi,

Fixes #201 by fine tuning the timer frequency. Basically, we get closer to the "ideal" timer frequency by this. Output frequency detuning shifts from 0.25% to 0.06%. To test this, I generated sinusoidal tones in Audacity and listen to the beating when superimposing them to the same tone generated by Mozzi. HiFi is 0.06% off in the native version so I did not touch that.

Untested with external audio, but that should behave the same. Of course, this changes the behavior of all sketches on AVR (but to be closer to reality which I think is fine!) 

Would love to have confirmation from someone else owning an AVR to be sure I am not looking to fix problems with the particular board I am testing with!