### PR TITLE
Github workflow: Revert version increas in checkout action

### DIFF
--- a/.github/workflows/compile_examples.yml
+++ b/.github/workflows/compile_examples.yml
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       - name: Compile examples
         uses: arduino/compile-sketches@v1


### PR DESCRIPTION
To test, whether this fixes the "report" stage on PR, or whether that breakage is due to something else.