### PR TITLE
Replaced unsigned long into uint32_t for Oscil.

### DIFF
--- a/Oscil.h
+++ b/Oscil.h
@@ -111,7 +111,7 @@ public:
 	// (in loop()), it's probably worth keeping it nonvolatile until it causes problems
 	void setPhase(unsigned int phase)
 	{
-		phase_fractional = (unsigned long)phase << OSCIL_F_BITS;
+		phase_fractional = (uint32_t)phase << OSCIL_F_BITS;
 	}
 
 	/** Set the phase of the Oscil.  Might be useful with getPhaseFractional().
@@ -120,7 +120,7 @@ public:
 	// This could be called in the control interrupt, so phase_fractional should really be volatile,
 	// but that could limit optimisation.  Since phase_fractional gets changed often in updateAudio()
 	// (in loop()), it's probably worth keeping it nonvolatile until it causes problems
-	void setPhaseFractional(unsigned long phase)
+	void setPhaseFractional(uint32_t phase)
 	{
 		phase_fractional = phase;
 	}
@@ -129,7 +129,7 @@ public:
 	/** Get the phase of the Oscil in fractional format.
 	@return position in the wavetable, shifted left by OSCIL_F_BITS (which is 16 when this was written).
 	*/
-	unsigned long getPhaseFractional()
+	uint32_t getPhaseFractional()
 	{
 		return phase_fractional;
 	}
@@ -165,9 +165,9 @@ public:
 	void setFreq (int frequency) {
 		// TB2014-8-20 change this following Austin Grossman's suggestion on user list
 		// https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/mozzi-users/u4D5NMzVnQs/pCmiWInFvrkJ
-		//phase_increment_fractional = ((((unsigned long)NUM_TABLE_CELLS<<ADJUST_FOR_NUM_TABLE_CELLS)*frequency)/UPDATE_RATE) << (OSCIL_F_BITS - ADJUST_FOR_NUM_TABLE_CELLS);
+		//phase_increment_fractional = ((((uint32_t)NUM_TABLE_CELLS<<ADJUST_FOR_NUM_TABLE_CELLS)*frequency)/UPDATE_RATE) << (OSCIL_F_BITS - ADJUST_FOR_NUM_TABLE_CELLS);
 		// to this:
-		phase_increment_fractional = ((unsigned long)frequency) * ((OSCIL_F_BITS_AS_MULTIPLIER*NUM_TABLE_CELLS)/UPDATE_RATE);
+		phase_increment_fractional = ((uint32_t)frequency) * ((OSCIL_F_BITS_AS_MULTIPLIER*NUM_TABLE_CELLS)/UPDATE_RATE);
 	}
 
 
@@ -179,7 +179,7 @@ public:
 	inline
 	void setFreq(float frequency)
 	{ // 1 us - using float doesn't seem to incur measurable overhead with the oscilloscope
-		phase_increment_fractional = (unsigned long)((((float)NUM_TABLE_CELLS * frequency)/UPDATE_RATE) * OSCIL_F_BITS_AS_MULTIPLIER);
+		phase_increment_fractional = (uint32_t)((((float)NUM_TABLE_CELLS * frequency)/UPDATE_RATE) * OSCIL_F_BITS_AS_MULTIPLIER);
 	}
 
 
@@ -195,15 +195,15 @@ public:
 	{
 		//phase_increment_fractional = (frequency* (NUM_TABLE_CELLS>>3)/(UPDATE_RATE>>6)) << (F_BITS-(8-3+6));
 // TB2016-10-2 line below might have been left in accidentally while making the 2014 change below, remove for now
-//		phase_increment_fractional = (((((unsigned long)NUM_TABLE_CELLS<<ADJUST_FOR_NUM_TABLE_CELLS)>>3)*frequency)/(UPDATE_RATE>>6))
+//		phase_increment_fractional = (((((uint32_t)NUM_TABLE_CELLS<<ADJUST_FOR_NUM_TABLE_CELLS)>>3)*frequency)/(UPDATE_RATE>>6))
 //		                             << (OSCIL_F_BITS - ADJUST_FOR_NUM_TABLE_CELLS - (8-3+6));
 
 		// TB2014-8-20 change this following Austin Grossman's suggestion on user list
 		// https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/mozzi-users/u4D5NMzVnQs/pCmiWInFvrkJ
 		if ((256UL*NUM_TABLE_CELLS) >= UPDATE_RATE) {
-			phase_increment_fractional = ((unsigned long)frequency) * ((256UL*NUM_TABLE_CELLS)/UPDATE_RATE);
+			phase_increment_fractional = ((uint32_t)frequency) * ((256UL*NUM_TABLE_CELLS)/UPDATE_RATE);
 		} else {
-			phase_increment_fractional = ((unsigned long)frequency) / (UPDATE_RATE/(256UL*NUM_TABLE_CELLS));
+			phase_increment_fractional = ((uint32_t)frequency) / (UPDATE_RATE/(256UL*NUM_TABLE_CELLS));
 		}
 	}
 
@@ -225,9 +225,9 @@ public:
 		//phase_increment_fractional = (((((uint32_t)NUM_TABLE_CELLS<<ADJUST_FOR_NUM_TABLE_CELLS)>>7)*frequency)/(UPDATE_RATE>>6))
 		//                             << (OSCIL_F_BITS - ADJUST_FOR_NUM_TABLE_CELLS - 16 + 1);
 		if (NUM_TABLE_CELLS >= UPDATE_RATE) {
-			phase_increment_fractional = ((unsigned long)frequency) * (NUM_TABLE_CELLS/UPDATE_RATE);
+			phase_increment_fractional = ((uint32_t)frequency) * (NUM_TABLE_CELLS/UPDATE_RATE);
 		} else {
-			phase_increment_fractional = ((unsigned long)frequency) / (UPDATE_RATE/NUM_TABLE_CELLS);
+			phase_increment_fractional = ((uint32_t)frequency) / (UPDATE_RATE/NUM_TABLE_CELLS);
 		}
 	}
 /*
@@ -259,12 +259,12 @@ public:
 	@return the phase increment value which will produce a given frequency.
 	*/
 	inline
-	unsigned long phaseIncFromFreq(int frequency)
+	uint32_t phaseIncFromFreq(int frequency)
 	{
 		// TB2014-8-20 change this following Austin Grossman's suggestion on user list
 		// https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/mozzi-users/u4D5NMzVnQs/pCmiWInFvrkJ
-		//return (((unsigned long)frequency * NUM_TABLE_CELLS)/UPDATE_RATE) << OSCIL_F_BITS;
-		return ((unsigned long)frequency) * ((OSCIL_F_BITS_AS_MULTIPLIER*NUM_TABLE_CELLS)/UPDATE_RATE);
+		//return (((uint32_t)frequency * NUM_TABLE_CELLS)/UPDATE_RATE) << OSCIL_F_BITS;
+		return ((uint32_t)frequency) * ((OSCIL_F_BITS_AS_MULTIPLIER*NUM_TABLE_CELLS)/UPDATE_RATE);
 	}
 
 
@@ -272,7 +272,7 @@ public:
 	@param phaseinc_fractional a phase increment value as calculated by phaseIncFromFreq().
 	 */
 	inline
-	void setPhaseInc(unsigned long phaseinc_fractional)
+	void setPhaseInc(uint32_t phaseinc_fractional)
 	{
 		phase_increment_fractional = phaseinc_fractional;
 	}
@@ -311,8 +311,8 @@ static const uint8_t ADJUST_FOR_NUM_TABLE_CELLS = (NUM_TABLE_CELLS<2048) ? 8 : 0
 	}
 
 
-	unsigned long phase_fractional;
-	unsigned long phase_increment_fractional;
+	uint32_t phase_fractional;
+	uint32_t phase_increment_fractional;
 	const int8_t * table;
 
 };


### PR DESCRIPTION
 Should optimize slightly for 32bitters.

This is very minor, will merge soon after a bit of extra testing.