### PR TITLE
Implementing auto Range for FixMath

### DIFF
--- a/FixMath.h
+++ b/FixMath.h
@@ -106,8 +106,8 @@ namespace MozziPrivate {
   template<typename T> constexpr T shiftR(T x, int8_t bits) {return (bits > 0 ? (x >> (bits)) : (x << (-bits)));}
   constexpr int8_t sBitsToBytes(int8_t N) { return (((N)>>3)+1);}
   constexpr int8_t uBitsToBytes(int8_t N) { return (((N-1)>>3)+1);}
-  template<typename T>  constexpr T MAX(T N1, T N2) { return (N1) > (N2) ? (N1) : (N2);}
-  template<typename T>  constexpr T MIN(T N1, T N2) { return (N1) > (N2) ? (N2) : (N1);}
+  template<typename T>  constexpr T mozziMax(T N1, T N2) { return (N1) > (N2) ? (N1) : (N2);}
+  template<typename T>  constexpr T mozziMin(T N1, T N2) { return (N1) > (N2) ? (N2) : (N1);}
   constexpr uint64_t sFullRange(int8_t N) { return uint64_t(1)<<N;}
   constexpr uint64_t uFullRange(int8_t N) { return ((uint64_t(1)<<(N-1))-1) + (uint64_t(1)<<(N-1));}
   constexpr uint64_t rangeAdd(byte NF, byte _NF, uint64_t RANGE, uint64_t _RANGE) { return ((NF > _NF) ? (RANGE + (_RANGE<<(NF-_NF))) : (_RANGE + (RANGE<<(_NF-NF))));}
@@ -183,7 +183,7 @@ public:
   */
   template<int8_t _NI, int8_t _NF, uint64_t _RANGE>
   UFixMath(const UFixMath<_NI,_NF, _RANGE>& uf) {
-    internal_value = MozziPrivate::shiftR((typename IntegerType<MozziPrivate::uBitsToBytes(MozziPrivate::MAX(NI+NF,_NI+_NF))>::unsigned_type) uf.asRaw(),(_NF-NF));
+    internal_value = MozziPrivate::shiftR((typename IntegerType<MozziPrivate::uBitsToBytes(MozziPrivate::mozziMax(NI+NF,_NI+_NF))>::unsigned_type) uf.asRaw(),(_NF-NF));
   }
 
 
@@ -194,7 +194,7 @@ public:
   */
   template<int8_t _NI, int8_t _NF, uint64_t _RANGE>
   UFixMath(const SFixMath<_NI,_NF, _RANGE>& uf) {
-    internal_value = MozziPrivate::shiftR((typename IntegerType<MozziPrivate::uBitsToBytes(MozziPrivate::MAX(NI+NF,_NI+_NF))>::unsigned_type) uf.asRaw(),(_NF-NF));
+    internal_value = MozziPrivate::shiftR((typename IntegerType<MozziPrivate::uBitsToBytes(MozziPrivate::mozziMax(NI+NF,_NI+_NF))>::unsigned_type) uf.asRaw(),(_NF-NF));
   }
 
 
@@ -205,11 +205,11 @@ public:
       @return The result of the addition as a UFixMath.
   */
    template<int8_t _NI, int8_t _NF, uint64_t _RANGE>
-   UFixMath<MozziPrivate::neededNIExtra(MozziPrivate::MAX(NI,_NI),MozziPrivate::MAX(NF,_NF),MozziPrivate::rangeAdd(NF,_NF,RANGE,_RANGE)),MozziPrivate::MAX(NF, _NF), MozziPrivate::rangeAdd(NF,_NF,RANGE,_RANGE)> operator+ (const UFixMath<_NI,_NF,_RANGE>& op) const
+   UFixMath<MozziPrivate::neededNIExtra(MozziPrivate::mozziMax(NI,_NI),MozziPrivate::mozziMax(NF,_NF),MozziPrivate::rangeAdd(NF,_NF,RANGE,_RANGE)),MozziPrivate::mozziMax(NF, _NF), MozziPrivate::rangeAdd(NF,_NF,RANGE,_RANGE)> operator+ (const UFixMath<_NI,_NF,_RANGE>& op) const
   {
     constexpr uint64_t new_RANGE = MozziPrivate::rangeAdd(NF,_NF,RANGE,_RANGE);
-    constexpr int8_t new_NI = MozziPrivate::neededNIExtra(MozziPrivate::MAX(NI,_NI),MozziPrivate::MAX(NF,_NF),new_RANGE);
-    constexpr int8_t new_NF = MozziPrivate::MAX(NF, _NF);
+    constexpr int8_t new_NI = MozziPrivate::neededNIExtra(MozziPrivate::mozziMax(NI,_NI),MozziPrivate::mozziMax(NF,_NF),new_RANGE);
+    constexpr int8_t new_NF = MozziPrivate::mozziMax(NF, _NF);
     typedef typename IntegerType<MozziPrivate::uBitsToBytes(new_NI+new_NF)>::unsigned_type return_type;
     UFixMath<new_NI,new_NF> left(*this);
     UFixMath<new_NI,new_NF> right(op);
@@ -223,11 +223,11 @@ public:
       @return The result of the addition as a SFixMath.
   */
    template<int8_t _NI, int8_t _NF, uint64_t _RANGE>
-   SFixMath<MozziPrivate::neededSNIExtra(MozziPrivate::MAX(NI,_NI),MozziPrivate::MAX(NF,_NF),MozziPrivate::rangeAdd(NF,_NF,RANGE,_RANGE)),MozziPrivate::MAX(NF, _NF), MozziPrivate::rangeAdd(NF,_NF,RANGE,_RANGE)> operator+ (const SFixMath<_NI,_NF,_RANGE>& op) const
+   SFixMath<MozziPrivate::neededSNIExtra(MozziPrivate::mozziMax(NI,_NI),MozziPrivate::mozziMax(NF,_NF),MozziPrivate::rangeAdd(NF,_NF,RANGE,_RANGE)),MozziPrivate::mozziMax(NF, _NF), MozziPrivate::rangeAdd(NF,_NF,RANGE,_RANGE)> operator+ (const SFixMath<_NI,_NF,_RANGE>& op) const
   {
     constexpr uint64_t new_RANGE = MozziPrivate::rangeAdd(NF,_NF,RANGE,_RANGE);
-    constexpr int8_t new_NI = MozziPrivate::neededSNIExtra(MozziPrivate::MAX(NI,_NI),MozziPrivate::MAX(NF,_NF),new_RANGE);
-    constexpr int8_t new_NF = MozziPrivate::MAX(NF, _NF);
+    constexpr int8_t new_NI = MozziPrivate::neededSNIExtra(MozziPrivate::mozziMax(NI,_NI),MozziPrivate::mozziMax(NF,_NF),new_RANGE);
+    constexpr int8_t new_NF = MozziPrivate::mozziMax(NF, _NF);
     typedef typename IntegerType<MozziPrivate::uBitsToBytes(new_NI+new_NF)>::signed_type return_type;
     SFixMath<new_NI,new_NF> left(*this);
     SFixMath<new_NI,new_NF> right(op);
@@ -254,17 +254,17 @@ public:
       @param op The UFixMath to be subtracted.
       @return The result of the subtraction as a SFixMath.
   */
-  template<int8_t _NI, int8_t _NF, uint64_t _RANGE> // We do not have the +1 after MozziPrivate::MAX(NI, _NI) because the substraction between two UFix should fit in the biggest of the two.
-  SFixMath<MozziPrivate::MAX(NI,_NI),MozziPrivate::MAX(NF,_NF), MozziPrivate::MAX(MozziPrivate::shiftR(RANGE,MozziPrivate::MAX(NF,_NF)-NF), MozziPrivate::shiftR(_RANGE,MozziPrivate::MAX(NF,_NF)-_NF))> operator- (const UFixMath<_NI,_NF, _RANGE>& op) const
+  template<int8_t _NI, int8_t _NF, uint64_t _RANGE> // We do not have the +1 after MozziPrivate::mozziMax(NI, _NI) because the substraction between two UFix should fit in the biggest of the two.
+  SFixMath<MozziPrivate::mozziMax(NI,_NI),MozziPrivate::mozziMax(NF,_NF), MozziPrivate::mozziMax(MozziPrivate::shiftR(RANGE,MozziPrivate::mozziMax(NF,_NF)-NF), MozziPrivate::shiftR(_RANGE,MozziPrivate::mozziMax(NF,_NF)-_NF))> operator- (const UFixMath<_NI,_NF, _RANGE>& op) const
   {
-    constexpr int8_t new_NI = MozziPrivate::MAX(NI, _NI);
-    constexpr int8_t new_NF = MozziPrivate::MAX(NF, _NF);
+    constexpr int8_t new_NI = MozziPrivate::mozziMax(NI, _NI);
+    constexpr int8_t new_NF = MozziPrivate::mozziMax(NF, _NF);
     typedef typename IntegerType<MozziPrivate::sBitsToBytes(new_NI+new_NF)>::signed_type return_type;
     SFixMath<new_NI,new_NF> left(*this);
     SFixMath<new_NI,new_NF> right(op);
 
     return_type tt = return_type(left.asRaw()) - right.asRaw();
-    return SFixMath<new_NI,new_NF,MozziPrivate::MAX(MozziPrivate::shiftR(RANGE,MozziPrivate::MAX(NF,_NF)-NF), MozziPrivate::shiftR(_RANGE,MozziPrivate::MAX(NF,_NF)-_NF))>(tt,true);
+    return SFixMath<new_NI,new_NF,MozziPrivate::mozziMax(MozziPrivate::shiftR(RANGE,MozziPrivate::mozziMax(NF,_NF)-NF), MozziPrivate::shiftR(_RANGE,MozziPrivate::mozziMax(NF,_NF)-_NF))>(tt,true);
   }
 
   #ifdef FIXMATHUNSAFE
@@ -359,7 +359,7 @@ public:
       This is still slower than a multiplication, hence the suggested workflow is to compute the inverse when time is not critical, for instance in updateControl(), and multiply it afterward, for instance in updateAudio(), if you need a division.
       @return The inverse of the number.
   */
-  UFixMath<NF,MozziPrivate::MIN(NI*2+NF,63-NF)> invAccurate() const // The MozziPrivate::MIN is just to remove compiler error when a big FixMath is instanciated but no accurate inverse is actually computed (this would be catch by the static_assert)
+  UFixMath<NF,MozziPrivate::mozziMin(NI*2+NF,63-NF)> invAccurate() const // The MozziPrivate::mozziMin is just to remove compiler error when a big FixMath is instanciated but no accurate inverse is actually computed (this would be catch by the static_assert)
   {
     static_assert(2*NI+2*NF<=63, "The accurate inverse cannot be computed for when 2*NI+2*NF>63. Reduce the number of bits.");
     return inv<NI*2+NF>();
@@ -400,9 +400,9 @@ public:
       @return The result of the shift as a UFixMath of smaller size.
   */
   template<int8_t op>
-  UFixMath<MozziPrivate::MAX(NI-op,0),NF+op, MozziPrivate::RANGESHIFT(NI,op,RANGE)> sR()
+  UFixMath<MozziPrivate::mozziMax(NI-op,0),NF+op, MozziPrivate::RANGESHIFT(NI,op,RANGE)> sR()
   {
-    return UFixMath<MozziPrivate::MAX(NI-op,0),NF+op,MozziPrivate::RANGESHIFT(NI,op,RANGE)>(internal_value,true);
+    return UFixMath<MozziPrivate::mozziMax(NI-op,0),NF+op,MozziPrivate::RANGESHIFT(NI,op,RANGE)>(internal_value,true);
   }
 
   /** Safe and optimal left shift. The returned type will be adjusted accordingly
@@ -410,9 +410,9 @@ public:
       @return The result of the shift as a UFixMath of bigger size.
   */
   template<int8_t op>
-  UFixMath<NI+op,MozziPrivate::MAX(NF-op,0),MozziPrivate::RANGESHIFT(NF,op,RANGE)> sL()
+  UFixMath<NI+op,MozziPrivate::mozziMax(NF-op,0),MozziPrivate::RANGESHIFT(NF,op,RANGE)> sL()
   {
-    return UFixMath<NI+op,MozziPrivate::MAX(NF-op,0)>(internal_value,true);
+    return UFixMath<NI+op,MozziPrivate::mozziMax(NF-op,0)>(internal_value,true);
   }
 
   
@@ -421,8 +421,8 @@ public:
   template<int8_t _NI, int8_t _NF>
   bool operator> (const UFixMath<_NI,_NF>& op) const
   {
-    constexpr int8_t new_NI = MozziPrivate::MAX(NI, _NI);
-    constexpr int8_t new_NF = MozziPrivate::MAX(NF, _NF);
+    constexpr int8_t new_NI = MozziPrivate::mozziMax(NI, _NI);
+    constexpr int8_t new_NF = MozziPrivate::mozziMax(NF, _NF);
     UFixMath<new_NI,new_NF> left(*this);
     UFixMath<new_NI,new_NF> right(op);
     return left.asRaw()>right.asRaw();
@@ -437,8 +437,8 @@ public:
   template<int8_t _NI, int8_t _NF>
   bool operator== (const UFixMath<_NI,_NF>& op) const
   {
-    constexpr int8_t new_NI = MozziPrivate::MAX(NI, _NI);
-    constexpr int8_t new_NF = MozziPrivate::MAX(NF, _NF);
+    constexpr int8_t new_NI = MozziPrivate::mozziMax(NI, _NI);
+    constexpr int8_t new_NF = MozziPrivate::mozziMax(NF, _NF);
     UFixMath<new_NI,new_NF> left(*this);
     UFixMath<new_NI,new_NF> right(op);
     return left.asRaw()==right.asRaw();
@@ -447,8 +447,8 @@ public:
   template<int8_t _NI, int8_t _NF>
   bool operator!= (const UFixMath<_NI,_NF>& op) const
   {
-    constexpr int8_t new_NI = MozziPrivate::MAX(NI, _NI);
-    constexpr int8_t new_NF = MozziPrivate::MAX(NF, _NF);
+    constexpr int8_t new_NI = MozziPrivate::mozziMax(NI, _NI);
+    constexpr int8_t new_NF = MozziPrivate::mozziMax(NF, _NF);
     UFixMath<new_NI,new_NF> left(*this);
     UFixMath<new_NI,new_NF> right(op);
     return left.asRaw()!=right.asRaw();
@@ -675,7 +675,7 @@ public:
   */
   template<int8_t _NI, int8_t _NF, uint64_t _RANGE>
   SFixMath(const SFixMath<_NI,_NF, _RANGE>& uf) {
-    internal_value = MozziPrivate::shiftR((typename IntegerType<MozziPrivate::sBitsToBytes(MozziPrivate::MAX(NI+NF,_NI+_NF))>::signed_type) uf.asRaw(),(_NF-NF));
+    internal_value = MozziPrivate::shiftR((typename IntegerType<MozziPrivate::sBitsToBytes(MozziPrivate::mozziMax(NI+NF,_NI+_NF))>::signed_type) uf.asRaw(),(_NF-NF));
     
   }
 
@@ -685,7 +685,7 @@ public:
   */
   template<int8_t _NI, int8_t _NF, uint64_t _RANGE>
   SFixMath(const UFixMath<_NI,_NF, _RANGE>& uf) {
-    internal_value = MozziPrivate::shiftR((typename IntegerType<MozziPrivate::uBitsToBytes(MozziPrivate::MAX(NI+NF,_NI+_NF))>::unsigned_type) uf.asRaw(),(_NF-NF));
+    internal_value = MozziPrivate::shiftR((typename IntegerType<MozziPrivate::uBitsToBytes(MozziPrivate::mozziMax(NI+NF,_NI+_NF))>::unsigned_type) uf.asRaw(),(_NF-NF));
   }
 
   //////// ADDITION OVERLOADS
@@ -695,11 +695,11 @@ public:
       @return The result of the addition as a SFixMath.
   */
   template<int8_t _NI, int8_t _NF, uint64_t _RANGE>
-  SFixMath<MozziPrivate::neededSNIExtra(MozziPrivate::MAX(NI,_NI),MozziPrivate::MAX(NF,_NF),MozziPrivate::rangeAdd(NF,_NF,RANGE,_RANGE)),MozziPrivate::MAX(NF, _NF), MozziPrivate::rangeAdd(NF,_NF,RANGE,_RANGE)> operator+ (const SFixMath<_NI,_NF,_RANGE>& op) const
+  SFixMath<MozziPrivate::neededSNIExtra(MozziPrivate::mozziMax(NI,_NI),MozziPrivate::mozziMax(NF,_NF),MozziPrivate::rangeAdd(NF,_NF,RANGE,_RANGE)),MozziPrivate::mozziMax(NF, _NF), MozziPrivate::rangeAdd(NF,_NF,RANGE,_RANGE)> operator+ (const SFixMath<_NI,_NF,_RANGE>& op) const
   {
     constexpr uint64_t new_RANGE = MozziPrivate::rangeAdd(NF,_NF,RANGE,_RANGE);
-    constexpr int8_t new_NI = MozziPrivate::neededSNIExtra(MozziPrivate::MAX(NI,_NI),MozziPrivate::MAX(NF,_NF),new_RANGE);
-    constexpr int8_t new_NF = MozziPrivate::MAX(NF, _NF);
+    constexpr int8_t new_NI = MozziPrivate::neededSNIExtra(MozziPrivate::mozziMax(NI,_NI),MozziPrivate::mozziMax(NF,_NF),new_RANGE);
+    constexpr int8_t new_NF = MozziPrivate::mozziMax(NF, _NF);
     typedef typename IntegerType<MozziPrivate::sBitsToBytes(new_NI+new_NF)>::signed_type return_type;
     SFixMath<new_NI,new_NF> left(*this);
     SFixMath<new_NI,new_NF> right(op);
@@ -727,11 +727,11 @@ public:
       @return The result of the subtraction as a SFixMath.
   */ 
   template<int8_t _NI, int8_t _NF, uint64_t _RANGE>
-  SFixMath<MozziPrivate::neededSNIExtra(MozziPrivate::MAX(NI,_NI),MozziPrivate::MAX(NF,_NF),MozziPrivate::rangeAdd(NF,_NF,RANGE,_RANGE)),MozziPrivate::MAX(NF, _NF), MozziPrivate::rangeAdd(NF,_NF,RANGE,_RANGE)> operator- (const SFixMath<_NI,_NF, _RANGE>& op) const
+  SFixMath<MozziPrivate::neededSNIExtra(MozziPrivate::mozziMax(NI,_NI),MozziPrivate::mozziMax(NF,_NF),MozziPrivate::rangeAdd(NF,_NF,RANGE,_RANGE)),MozziPrivate::mozziMax(NF, _NF), MozziPrivate::rangeAdd(NF,_NF,RANGE,_RANGE)> operator- (const SFixMath<_NI,_NF, _RANGE>& op) const
   {
     constexpr uint64_t new_RANGE = MozziPrivate::rangeAdd(NF,_NF,RANGE,_RANGE);
-    constexpr int8_t new_NI = MozziPrivate::neededSNIExtra(MozziPrivate::MAX(NI,_NI),MozziPrivate::MAX(NF,_NF),new_RANGE);
-    constexpr int8_t new_NF = MozziPrivate::MAX(NF, _NF);
+    constexpr int8_t new_NI = MozziPrivate::neededSNIExtra(MozziPrivate::mozziMax(NI,_NI),MozziPrivate::mozziMax(NF,_NF),new_RANGE);
+    constexpr int8_t new_NF = MozziPrivate::mozziMax(NF, _NF);
     typedef typename IntegerType<MozziPrivate::sBitsToBytes(new_NI+new_NF)>::signed_type return_type;
     SFixMath<new_NI,new_NF> left(*this);
     SFixMath<new_NI,new_NF> right(op);
@@ -744,11 +744,11 @@ public:
       @return The result of the subtraction as a SFixMath.
   */ 
   template<int8_t _NI, int8_t _NF, uint64_t _RANGE>
-  SFixMath<MozziPrivate::neededSNIExtra(MozziPrivate::MAX(NI,_NI),MozziPrivate::MAX(NF,_NF),MozziPrivate::rangeAdd(NF,_NF,RANGE,_RANGE)),MozziPrivate::MAX(NF, _NF), MozziPrivate::rangeAdd(NF,_NF,RANGE,_RANGE)> operator- (const UFixMath<_NI,_NF, _RANGE>& op) const
+  SFixMath<MozziPrivate::neededSNIExtra(MozziPrivate::mozziMax(NI,_NI),MozziPrivate::mozziMax(NF,_NF),MozziPrivate::rangeAdd(NF,_NF,RANGE,_RANGE)),MozziPrivate::mozziMax(NF, _NF), MozziPrivate::rangeAdd(NF,_NF,RANGE,_RANGE)> operator- (const UFixMath<_NI,_NF, _RANGE>& op) const
   {
     constexpr uint64_t new_RANGE = MozziPrivate::rangeAdd(NF,_NF,RANGE,_RANGE);
-    constexpr int8_t new_NI = MozziPrivate::neededSNIExtra(MozziPrivate::MAX(NI,_NI),MozziPrivate::MAX(NF,_NF),new_RANGE);
-    constexpr int8_t new_NF = MozziPrivate::MAX(NF, _NF);
+    constexpr int8_t new_NI = MozziPrivate::neededSNIExtra(MozziPrivate::mozziMax(NI,_NI),MozziPrivate::mozziMax(NF,_NF),new_RANGE);
+    constexpr int8_t new_NF = MozziPrivate::mozziMax(NF, _NF);
     typedef typename IntegerType<MozziPrivate::sBitsToBytes(new_NI+new_NF)>::signed_type return_type;
     SFixMath<new_NI,new_NF> left(*this);
     SFixMath<new_NI,new_NF> right(op);
@@ -834,7 +834,7 @@ public:
       This is still slower than a multiplication, hence the suggested workflow is to compute the inverse when time is not critical, for instance in updateControl(), and multiply it afterward, for instance in updateAudio(), if you need a division.
       @return The inverse of the number.
   */
-  SFixMath<NF,MozziPrivate::MIN(NI*2+NF,62-NF)> invAccurate() const
+  SFixMath<NF,MozziPrivate::mozziMin(NI*2+NF,62-NF)> invAccurate() const
   {
     return inv<NI*2+NF>();
     }
@@ -869,9 +869,9 @@ public:
       @return The result of the shift as a UFixMath of smaller size.
   */
   template<int8_t op>
-  SFixMath<MozziPrivate::MAX(NI-op,0), NF+op, MozziPrivate::RANGESHIFT(NI,op,RANGE)> sR()
+  SFixMath<MozziPrivate::mozziMax(NI-op,0), NF+op, MozziPrivate::RANGESHIFT(NI,op,RANGE)> sR()
   {
-    return SFixMath<MozziPrivate::MAX(NI-op,0),NF+op,MozziPrivate::RANGESHIFT(NI,op,RANGE)>(internal_value,true);
+    return SFixMath<MozziPrivate::mozziMax(NI-op,0),NF+op,MozziPrivate::RANGESHIFT(NI,op,RANGE)>(internal_value,true);
   }
 
   /** Safe and optimal left shift. The returned type will be adjusted accordingly
@@ -879,9 +879,9 @@ public:
       @return The result of the shift as a UFixMath of bigger size.
   */
 template<int8_t op>
-  SFixMath<NI+op,MozziPrivate::MAX(NF-op,0),MozziPrivate::RANGESHIFT(NF,op,RANGE)> sL()
+  SFixMath<NI+op,MozziPrivate::mozziMax(NF-op,0),MozziPrivate::RANGESHIFT(NF,op,RANGE)> sL()
   {
-    return SFixMath<NI+op,MozziPrivate::MAX(NF-op,0)>(internal_value,true);
+    return SFixMath<NI+op,MozziPrivate::mozziMax(NF-op,0)>(internal_value,true);
   }
 
 
@@ -890,8 +890,8 @@ template<int8_t op>
   template<int8_t _NI, int8_t _NF>
   bool operator> (const SFixMath<_NI,_NF>& op) const
   {
-    constexpr int8_t new_NI = MozziPrivate::MAX(NI, _NI);
-    constexpr int8_t new_NF = MozziPrivate::MAX(NF, _NF);
+    constexpr int8_t new_NI = MozziPrivate::mozziMax(NI, _NI);
+    constexpr int8_t new_NF = MozziPrivate::mozziMax(NF, _NF);
     SFixMath<new_NI,new_NF> left(*this);
     SFixMath<new_NI,new_NF> right(op);
     return left.asRaw()>right.asRaw();
@@ -906,8 +906,8 @@ template<int8_t op>
   template<int8_t _NI, int8_t _NF>
   bool operator== (const SFixMath<_NI,_NF>& op) const
   {
-    constexpr int8_t new_NI = MozziPrivate::MAX(NI, _NI);
-    constexpr int8_t new_NF = MozziPrivate::MAX(NF, _NF);
+    constexpr int8_t new_NI = MozziPrivate::mozziMax(NI, _NI);
+    constexpr int8_t new_NF = MozziPrivate::mozziMax(NF, _NF);
     SFixMath<new_NI,new_NF> left(*this);
     SFixMath<new_NI,new_NF> right(op);
     return left.asRaw()==right.asRaw();
@@ -916,8 +916,8 @@ template<int8_t op>
   template<int8_t _NI, int8_t _NF>
   bool operator!= (const SFixMath<_NI,_NF>& op) const
   {
-    constexpr int8_t new_NI = MozziPrivate::MAX(NI, _NI);
-    constexpr int8_t new_NF = MozziPrivate::MAX(NF, _NF);
+    constexpr int8_t new_NI = MozziPrivate::mozziMax(NI, _NI);
+    constexpr int8_t new_NF = MozziPrivate::mozziMax(NF, _NF);
     SFixMath<new_NI,new_NF> left(*this);
     SFixMath<new_NI,new_NF> right(op);
     return left.asRaw()!=right.asRaw();
@@ -1069,7 +1069,7 @@ inline SFixMath<NI, NF> operator-(double op, const SFixMath<NI, NF>& uf) {return
     @return The result of the addition of op1 and op2. As a SFixMath
 */
 template<int8_t NI, int8_t NF, uint64_t RANGE, int8_t _NI, int8_t _NF, uint64_t _RANGE>
-inline SFixMath<MozziPrivate::neededSNIExtra(MozziPrivate::MAX(NI,_NI),MozziPrivate::MAX(NF,_NF),MozziPrivate::rangeAdd(NF,_NF,RANGE,_RANGE)),MozziPrivate::MAX(NF, _NF), MozziPrivate::rangeAdd(NF,_NF,RANGE,_RANGE)> operator+ (const SFixMath<NI,NF,RANGE>& op1, const UFixMath<_NI,_NF,_RANGE>& op2 )
+inline SFixMath<MozziPrivate::neededSNIExtra(MozziPrivate::mozziMax(NI,_NI),MozziPrivate::mozziMax(NF,_NF),MozziPrivate::rangeAdd(NF,_NF,RANGE,_RANGE)),MozziPrivate::mozziMax(NF, _NF), MozziPrivate::rangeAdd(NF,_NF,RANGE,_RANGE)> operator+ (const SFixMath<NI,NF,RANGE>& op1, const UFixMath<_NI,_NF,_RANGE>& op2 )
 {
   return op2+op1;
   }
@@ -1081,7 +1081,7 @@ inline SFixMath<MozziPrivate::neededSNIExtra(MozziPrivate::MAX(NI,_NI),MozziPriv
     @return The result of the subtraction of op1 by op2. As a SFixMath
 */
 template<int8_t NI, int8_t NF, uint64_t RANGE, int8_t _NI, int8_t _NF, uint64_t _RANGE>
-inline SFixMath<MozziPrivate::neededSNIExtra(MozziPrivate::MAX(NI,_NI),MozziPrivate::MAX(NF,_NF),MozziPrivate::rangeAdd(NF,_NF,RANGE,_RANGE)),MozziPrivate::MAX(NF, _NF), MozziPrivate::rangeAdd(NF,_NF,RANGE,_RANGE)> operator- (const UFixMath<NI,NF, RANGE>& op1, const SFixMath<_NI,_NF, _RANGE>& op2)
+inline SFixMath<MozziPrivate::neededSNIExtra(MozziPrivate::mozziMax(NI,_NI),MozziPrivate::mozziMax(NF,_NF),MozziPrivate::rangeAdd(NF,_NF,RANGE,_RANGE)),MozziPrivate::mozziMax(NF, _NF), MozziPrivate::rangeAdd(NF,_NF,RANGE,_RANGE)> operator- (const UFixMath<NI,NF, RANGE>& op1, const SFixMath<_NI,_NF, _RANGE>& op2)
 {
   return -op2+op1;
   }
@@ -1103,8 +1103,8 @@ inline SFixMath<MozziPrivate::neededSNIExtra(NI+_NI, NF+_NF, RANGE*_RANGE),NF+_N
 template<int8_t NI, int8_t NF, int8_t _NI, int8_t _NF>
 inline bool operator> (const SFixMath<NI,NF>& op1, const UFixMath<_NI,_NF>& op2 )
 {
-  constexpr int8_t new_NI = MozziPrivate::MAX(NI, _NI);
-  constexpr int8_t new_NF = MozziPrivate::MAX(NF, _NF);    
+  constexpr int8_t new_NI = MozziPrivate::mozziMax(NI, _NI);
+  constexpr int8_t new_NF = MozziPrivate::mozziMax(NF, _NF);    
   SFixMath<new_NI,new_NF> left(op1);
   SFixMath<new_NI,new_NF> right(op2);
   return left.asRaw() > right.asRaw();
@@ -1113,8 +1113,8 @@ inline bool operator> (const SFixMath<NI,NF>& op1, const UFixMath<_NI,_NF>& op2 
 template<int8_t NI, int8_t NF, int8_t _NI, int8_t _NF>
 inline bool operator> (const UFixMath<NI,NF>& op1, const SFixMath<_NI,_NF>& op2 )
 {
-  constexpr int8_t new_NI = MozziPrivate::MAX(NI, _NI);
-  constexpr int8_t new_NF = MozziPrivate::MAX(NF, _NF);    
+  constexpr int8_t new_NI = MozziPrivate::mozziMax(NI, _NI);
+  constexpr int8_t new_NF = MozziPrivate::mozziMax(NF, _NF);    
   SFixMath<new_NI,new_NF> left(op1);
   SFixMath<new_NI,new_NF> right(op2);
   return left.asRaw() > right.asRaw();
@@ -1137,8 +1137,8 @@ inline bool operator< (const SFixMath<NI,NF>& op1, const UFixMath<_NI,_NF>& op2 
 template<int8_t NI, int8_t NF, int8_t _NI, int8_t _NF>
 inline bool operator== (const SFixMath<NI,NF>& op1, const UFixMath<_NI,_NF>& op2 )
 {
-  constexpr int8_t new_NI = MozziPrivate::MAX(NI, _NI);
-  constexpr int8_t new_NF = MozziPrivate::MAX(NF, _NF);    
+  constexpr int8_t new_NI = MozziPrivate::mozziMax(NI, _NI);
+  constexpr int8_t new_NF = MozziPrivate::mozziMax(NF, _NF);    
   SFixMath<new_NI,new_NF> left(op1);
   SFixMath<new_NI,new_NF> right(op2);
   return left.asRaw() == right.asRaw();
@@ -1153,8 +1153,8 @@ inline bool operator== (const UFixMath<NI,NF>& op1, const SFixMath<_NI,_NF>& op2
 template<int8_t NI, int8_t NF, int8_t _NI, int8_t _NF>
 inline bool operator!= (const SFixMath<NI,NF>& op1, const UFixMath<_NI,_NF>& op2 )
 {
-  constexpr int8_t new_NI = MozziPrivate::MAX(NI, _NI);
-  constexpr int8_t new_NF = MozziPrivate::MAX(NF, _NF);    
+  constexpr int8_t new_NI = MozziPrivate::mozziMax(NI, _NI);
+  constexpr int8_t new_NF = MozziPrivate::mozziMax(NF, _NF);    
   SFixMath<new_NI,new_NF> left(op1);
   SFixMath<new_NI,new_NF> right(op2);
   return left.asRaw() != right.asRaw();

--- a/FixMath.h
+++ b/FixMath.h
@@ -442,8 +442,14 @@ public:
     UFixMath<new_NI,new_NF> right(op);
     return left.asRaw()!=right.asRaw();
   }
-
-
+  
+  /** Returns the number as a SFixMath of same range and precision. This is more optimized than a cast.
+      @return a SFixMath 
+  */
+  SFixMath<NI,NF,RANGE> asSFix()
+  {
+    return SFixMath<NI,NF,RANGE>(internal_value,true);
+  }
 
   /** Returns the value as floating point number.
       @return The floating point value.
@@ -904,6 +910,15 @@ template<int8_t op>
     SFixMath<new_NI,new_NF> left(*this);
     SFixMath<new_NI,new_NF> right(op);
     return left.asRaw()!=right.asRaw();
+  }
+
+
+  /** Returns the number as a UFixMath of same (positive) range and precision. The initial value has to be positive to return something correct. This is more optimized than a cast.
+      @return a UFixMath 
+  */
+  UFixMath<NI,NF,RANGE> asUFix()
+  {
+    return UFixMath<NI,NF,RANGE>(internal_value,true);
   }
   
 

--- a/FixMath.h
+++ b/FixMath.h
@@ -221,10 +221,10 @@ public:
       @return The result of the addition as a SFixMath.
   */
    template<int8_t _NI, int8_t _NF, uint64_t _RANGE>
-   SFixMath<NEEDEDNIEXTRA(MAX(NI,_NI),MAX(NF,_NF),RANGEADD(NF,_NF,RANGE,_RANGE)),MAX(NF, _NF), RANGEADD(NF,_NF,RANGE,_RANGE)> operator+ (const SFixMath<_NI,_NF,_RANGE>& op) const
+   SFixMath<NEEDEDSNIEXTRA(MAX(NI,_NI),MAX(NF,_NF),RANGEADD(NF,_NF,RANGE,_RANGE)),MAX(NF, _NF), RANGEADD(NF,_NF,RANGE,_RANGE)> operator+ (const SFixMath<_NI,_NF,_RANGE>& op) const
   {
     constexpr uint64_t new_RANGE = RANGEADD(NF,_NF,RANGE,_RANGE);
-    constexpr int8_t new_NI = NEEDEDNIEXTRA(MAX(NI,_NI),MAX(NF,_NF),new_RANGE);
+    constexpr int8_t new_NI = NEEDEDSNIEXTRA(MAX(NI,_NI),MAX(NF,_NF),new_RANGE);
     constexpr int8_t new_NF = MAX(NF, _NF);
     typedef typename IntegerType<MozziPrivate::uBitsToBytes(new_NI+new_NF)>::signed_type return_type;
     SFixMath<new_NI,new_NF> left(*this);
@@ -710,6 +710,26 @@ public:
     return SFixMath<new_NI, new_NF, new_RANGE>(tt,true);
   }
 
+    /** Addition with a UFixMath. Safe.
+      @param op The UFixMath to be added.
+      @return The result of the addition as a SFixMath.
+  */
+  /*template<int8_t _NI, int8_t _NF, uint64_t _RANGE>  
+  SFixMath<NEEDEDSNIEXTRA(MAX(NI,_NI),MAX(NF,_NF),RANGEADD(NF,_NF,RANGE,_RANGE)),MAX(NF, _NF), RANGEADD(NF,_NF,RANGE,_RANGE)> operator+ (const UFixMath<_NI,_NF,_RANGE>& op) const
+  {
+    constexpr uint64_t new_RANGE = RANGEADD(NF,_NF,RANGE,_RANGE);
+    constexpr int8_t new_NI = NEEDEDSNIEXTRA(MAX(NI,_NI),MAX(NF,_NF),new_RANGE);
+    constexpr int8_t new_NF = MAX(NF, _NF);
+    typedef typename IntegerType<MozziPrivate::sBitsToBytes(new_NI+new_NF)>::signed_type return_type;
+    SFixMath<new_NI,new_NF> left(*this);
+    SFixMath<new_NI,new_NF> right(op);
+
+    return_type tt = return_type(left.asRaw()) + right.asRaw();
+    return SFixMath<new_NI, new_NF, new_RANGE>(tt,true);
+    }*/
+
+  
+
   /** Addition with another type. Unsafe
       @param op The number to be added.
       @return The result of the addition as a UFixMath.
@@ -730,6 +750,24 @@ public:
   template<int8_t _NI, int8_t _NF, uint64_t _RANGE>
   //SFixMath<MAX(NI,_NI)+1,MAX(NF,_NF)> operator- (const SFixMath<_NI,_NF>& op) const
   SFixMath<NEEDEDSNIEXTRA(MAX(NI,_NI),MAX(NF,_NF),RANGEADD(NF,_NF,RANGE,_RANGE)),MAX(NF, _NF), RANGEADD(NF,_NF,RANGE,_RANGE)> operator- (const SFixMath<_NI,_NF, _RANGE>& op) const
+  {
+    constexpr uint64_t new_RANGE = RANGEADD(NF,_NF,RANGE,_RANGE);
+    constexpr int8_t new_NI = NEEDEDSNIEXTRA(MAX(NI,_NI),MAX(NF,_NF),new_RANGE);
+    constexpr int8_t new_NF = MAX(NF, _NF);
+    typedef typename IntegerType<MozziPrivate::sBitsToBytes(new_NI+new_NF)>::signed_type return_type;
+    SFixMath<new_NI,new_NF> left(*this);
+    SFixMath<new_NI,new_NF> right(op);
+    return_type tt = return_type(left.asRaw()) - return_type(right.asRaw());
+    return SFixMath<new_NI, new_NF, new_RANGE>(tt,true);
+  }
+
+    /** Subtraction with a UFixMath. Safe.
+      @param op The SFixMath to be subtracted.
+      @return The result of the subtraction as a SFixMath.
+  */ 
+  template<int8_t _NI, int8_t _NF, uint64_t _RANGE>
+  //SFixMath<MAX(NI,_NI)+1,MAX(NF,_NF)> operator- (const SFixMath<_NI,_NF>& op) const
+  SFixMath<NEEDEDSNIEXTRA(MAX(NI,_NI),MAX(NF,_NF),RANGEADD(NF,_NF,RANGE,_RANGE)),MAX(NF, _NF), RANGEADD(NF,_NF,RANGE,_RANGE)> operator- (const UFixMath<_NI,_NF, _RANGE>& op) const
   {
     constexpr uint64_t new_RANGE = RANGEADD(NF,_NF,RANGE,_RANGE);
     constexpr int8_t new_NI = NEEDEDSNIEXTRA(MAX(NI,_NI),MAX(NF,_NF),new_RANGE);
@@ -1084,25 +1122,25 @@ inline SFixMath<NEEDEDNIEXTRA(MAX(NI,_NI),MAX(NF,_NF)> operator+ (const SFixMath
   return SFixMath<new_NI,new_NF>(tt,true);
   }*/
 
-/** Addition between a UFixMath and a SFixMath. Safe.
-    @param op1 A UFixMath
-    @param op2 A SFixMath
+/** Addition between a SFixMath and a UFixMath. Safe.
+    @param op1 A SFixMath
+    @param op2 A UFixMath
     @return The result of the addition of op1 and op2. As a SFixMath
 */
 template<int8_t NI, int8_t NF, uint64_t RANGE, int8_t _NI, int8_t _NF, uint64_t _RANGE>
-SFixMath<NEEDEDNIEXTRA(MAX(NI,_NI),MAX(NF,_NF),RANGEADD(NF,_NF,RANGE,_RANGE)),MAX(NF, _NF), RANGEADD(NF,_NF,RANGE,_RANGE)> operator+ (const SFixMath<NI,NF,RANGE>& op1, const UFixMath<_NI,_NF,_RANGE>& op2 )
+SFixMath<NEEDEDSNIEXTRA(MAX(NI,_NI),MAX(NF,_NF),RANGEADD(NF,_NF,RANGE,_RANGE)),MAX(NF, _NF), RANGEADD(NF,_NF,RANGE,_RANGE)> operator+ (const SFixMath<NI,NF,RANGE>& op1, const UFixMath<_NI,_NF,_RANGE>& op2 )
 {
   return op2+op1;
   }
 
-// Substraction between SFixMath and UFixMath (promotion to next SFixMath)
+// Substraction between UFixMath and SFixMath
 
 /** Subtraction between a SFixMath and a UFixMath. Safe.
     @param op1 A SFixMath
     @param op2 A UFixMath
     @return The result of the subtraction of op1 by op2. As a SFixMath
 */
-template<int8_t NI, int8_t NF, int8_t _NI, int8_t _NF>
+/*template<int8_t NI, int8_t NF, int8_t _NI, int8_t _NF>
 inline SFixMath<MAX(NI,_NI)+1,MAX(NF,_NF)> operator- (const SFixMath<NI,NF>& op1, const UFixMath<_NI,_NF>& op2 )
 {
   constexpr int8_t new_NI = MAX(NI, _NI) + 1;
@@ -1113,18 +1151,18 @@ inline SFixMath<MAX(NI,_NI)+1,MAX(NF,_NF)> operator- (const SFixMath<NI,NF>& op1
   SFixMath<new_NI,new_NF> right(op2);
   return_type tt = return_type(left.asRaw()) - right.asRaw();
   return SFixMath<new_NI,new_NF>(tt,true);
-}
+  }*/
 
 /** Subtraction between a UFixMath and a SFixMath. Safe.
     @param op1 A UFixMath
     @param op2 A SFixMath
     @return The result of the subtraction of op1 by op2. As a SFixMath
 */
-template<int8_t NI, int8_t NF, int8_t _NI, int8_t _NF>
-inline SFixMath<MAX(NI,_NI)+1,MAX(NF,_NF)> operator- (const UFixMath<NI,NF>& op1, const SFixMath<_NI,_NF>& op2 )
+template<int8_t NI, int8_t NF, uint64_t RANGE, int8_t _NI, int8_t _NF, uint64_t _RANGE>
+inline SFixMath<NEEDEDSNIEXTRA(MAX(NI,_NI),MAX(NF,_NF),RANGEADD(NF,_NF,RANGE,_RANGE)),MAX(NF, _NF), RANGEADD(NF,_NF,RANGE,_RANGE)> operator- (const UFixMath<NI,NF, RANGE>& op1, const SFixMath<_NI,_NF, _RANGE>& op2)
 {
   return -op2+op1;
-}
+  }
 
 // Comparaison between SFixMath and UFixmath
 

--- a/FixMath.h
+++ b/FixMath.h
@@ -176,13 +176,13 @@ public:
   }
 
 
-  // IS THAT REALLY NEEDED?
-  /** Constructor from another SFixMath. 
+
+  /** Constructor from a SFixMath. 
       @param uf An signed fixed type number which value can be represented in this type: sign is thus discarded.
       @return A unsigned fixed type number
   */
-  template<int8_t _NI, int8_t _NF>
-  UFixMath(const SFixMath<_NI,_NF>& uf) {
+  template<int8_t _NI, int8_t _NF, uint64_t _RANGE>
+  UFixMath(const SFixMath<_NI,_NF, _RANGE>& uf) {
     internal_value = MOZZI_SHIFTR((typename IntegerType<MozziPrivate::uBitsToBytes(MAX(NI+NF,_NI+_NF))>::unsigned_type) uf.asRaw(),(_NF-NF));
   }
 
@@ -662,12 +662,12 @@ public:
     
   }
 
-  /** Constructor from another UFixMath. 
+  /** Constructor from an UFixMath. 
       @param uf A unsigned fixed type number which value can be represented in this type.
       @return A signed fixed type number
   */
-  template<int8_t _NI, int8_t _NF>
-  SFixMath(const UFixMath<_NI,_NF>& uf) {
+  template<int8_t _NI, int8_t _NF, uint64_t _RANGE>
+  SFixMath(const UFixMath<_NI,_NF, _RANGE>& uf) {
     internal_value = MOZZI_SHIFTR((typename IntegerType<MozziPrivate::uBitsToBytes(MAX(NI+NF,_NI+_NF))>::unsigned_type) uf.asRaw(),(_NF-NF));
   }
 

--- a/FixMath.h
+++ b/FixMath.h
@@ -216,6 +216,25 @@ public:
     return UFixMath<new_NI,new_NF,new_RANGE>(tt,true);
     }
 
+    /** Addition with a SFixMath. Safe.
+      @param op The UFixMath to be added.
+      @return The result of the addition as a SFixMath.
+  */
+   template<int8_t _NI, int8_t _NF, uint64_t _RANGE>
+   SFixMath<NEEDEDNIEXTRA(MAX(NI,_NI),MAX(NF,_NF),RANGEADD(NF,_NF,RANGE,_RANGE)),MAX(NF, _NF), RANGEADD(NF,_NF,RANGE,_RANGE)> operator+ (const SFixMath<_NI,_NF,_RANGE>& op) const
+  {
+    constexpr uint64_t new_RANGE = RANGEADD(NF,_NF,RANGE,_RANGE);
+    constexpr int8_t new_NI = NEEDEDNIEXTRA(MAX(NI,_NI),MAX(NF,_NF),new_RANGE);
+    constexpr int8_t new_NF = MAX(NF, _NF);
+    typedef typename IntegerType<MozziPrivate::uBitsToBytes(new_NI+new_NF)>::signed_type return_type;
+    SFixMath<new_NI,new_NF> left(*this);
+    SFixMath<new_NI,new_NF> right(op);
+
+    return_type tt = return_type(left.asRaw()) + right.asRaw();
+    return SFixMath<new_NI,new_NF,new_RANGE>(tt,true);
+    }
+  
+
   /** Addition with another type. Unsafe
       @param op The number to be added.
       @return The result of the addition as a UFixMath.
@@ -1052,8 +1071,8 @@ inline SFixMath<NI+_NI,NF+_NF> operator* (const UFixMath<NI,NF>& op1, const SFix
     @param op2 A UFixMath
     @return The result of the addition of op1 and op2. As a SFixMath
 */
-template<int8_t NI, int8_t NF, int8_t _NI, int8_t _NF>
-inline SFixMath<MAX(NI,_NI)+1,MAX(NF,_NF)> operator+ (const SFixMath<NI,NF>& op1, const UFixMath<_NI,_NF>& op2 )
+/*template<int8_t NI, int8_t NF, int8_t _NI, int8_t _NF>
+inline SFixMath<NEEDEDNIEXTRA(MAX(NI,_NI),MAX(NF,_NF)> operator+ (const SFixMath<NI,NF>& op1, const UFixMath<_NI,_NF>& op2 )
 {
   constexpr int8_t new_NI = MAX(NI, _NI) + 1;
   constexpr int8_t new_NF = MAX(NF, _NF);
@@ -1063,18 +1082,18 @@ inline SFixMath<MAX(NI,_NI)+1,MAX(NF,_NF)> operator+ (const SFixMath<NI,NF>& op1
   SFixMath<new_NI,new_NF> right(op2);
   return_type tt = return_type(left.asRaw()) + right.asRaw();
   return SFixMath<new_NI,new_NF>(tt,true);
-}
+  }*/
 
 /** Addition between a UFixMath and a SFixMath. Safe.
     @param op1 A UFixMath
     @param op2 A SFixMath
     @return The result of the addition of op1 and op2. As a SFixMath
 */
-template<int8_t NI, int8_t NF, int8_t _NI, int8_t _NF>
-inline SFixMath<MAX(NI,_NI)+1,MAX(NF,_NF)> operator+ (const UFixMath<NI,NF>& op1, const SFixMath<_NI,_NF>& op2 )
+template<int8_t NI, int8_t NF, uint64_t RANGE, int8_t _NI, int8_t _NF, uint64_t _RANGE>
+SFixMath<NEEDEDNIEXTRA(MAX(NI,_NI),MAX(NF,_NF),RANGEADD(NF,_NF,RANGE,_RANGE)),MAX(NF, _NF), RANGEADD(NF,_NF,RANGE,_RANGE)> operator+ (const SFixMath<NI,NF,RANGE>& op1, const UFixMath<_NI,_NF,_RANGE>& op2 )
 {
   return op2+op1;
-}
+  }
 
 // Substraction between SFixMath and UFixMath (promotion to next SFixMath)
 

--- a/FixMath.h
+++ b/FixMath.h
@@ -70,8 +70,9 @@
 #define MOZZI_SHIFTR(x,bits) (bits > 0 ? (x >> (bits)) : (x << (-bits))) // shift right for positive shift numbers, and left for negative ones.
 #define MAX(N1,N2) ((N1) > (N2) ? (N1) : (N2))
 #define MIN(N1,N2) ((N1) > (N2) ? (N2) : (N1))
-#define UFULLRANGE(N) ((1ULL<<(N)) - 1) // MAX value represented by an unsigned of N bits
+//#define UFULLRANGE(N) ((1ULL<<(N)) - 1) // MAX value represented by an unsigned of N bits
 #define SFULLRANGE(N) ((1ULL<<(N))) // MAX value represented by a signed of N bits
+#define UFULLRANGE(N) (((1ULL<<(N-1)) - 1) + (1ULL << (N-1)))
 #define RANGEADD(NF, _NF, RANGE, _RANGE) ((NF > _NF) ? (RANGE + (_RANGE<<(NF-_NF))) : (_RANGE + (RANGE<<(_NF-NF))))  // resulting range when adding
 #define NEEDEDNIEXTRA(NI, NF, RANGE) (RANGE > (UFULLRANGE(NI+NF)) ? (NI+1) : (RANGE > (UFULLRANGE(NI+NF-1)) ? (NI) : (NI-1)))  // NEEDED NI TO AVOID OVERFLOW, GIVEN A RANGE
 #define NEEDEDSNIEXTRA(NI, NF, RANGE) (RANGE > (SFULLRANGE(NI+NF)) ? (NI+1) : (RANGE > (SFULLRANGE(NI+NF-1)) ? (NI) : (NI-1)))

--- a/FixMath.h
+++ b/FixMath.h
@@ -101,7 +101,7 @@ namespace MozziPrivate {
 }
 
 // Forward declaration
-template<byte NI, byte NF>
+template<byte NI, byte NF, uint64_t RANGE=FULLRANGE(NI)>
 class SFixMath;
 
 
@@ -217,8 +217,8 @@ public:
       @param op The UFixMath to be subtracted.
       @return The result of the subtraction as a SFixMath.
   */
-  template<byte _NI, byte _NF> // We do not have the +1 after MAX(NI, _NI) because the substraction between two UFix should fit in the biggest of the two.
-  SFixMath<MAX(NI,_NI),MAX(NF,_NF)> operator- (const UFixMath<_NI,_NF>& op) const
+  template<byte _NI, byte _NF, uint64_t _RANGE> // We do not have the +1 after MAX(NI, _NI) because the substraction between two UFix should fit in the biggest of the two.
+  SFixMath<MAX(NI,_NI),MAX(NF,_NF), MAX(RANGE, _RANGE)> operator- (const UFixMath<_NI,_NF, _RANGE>& op) const
   {
     constexpr byte new_NI = MAX(NI, _NI);
     constexpr byte new_NF = MAX(NF, _NF);
@@ -227,7 +227,7 @@ public:
     SFixMath<new_NI,new_NF> right(op);
 
     return_type tt = return_type(left.asRaw()) - right.asRaw();
-    return SFixMath<new_NI,new_NF>(tt,true);
+    return SFixMath<new_NI,new_NF,MAX(RANGE,_RANGE)>(tt,true);
   }
 
   
@@ -240,6 +240,7 @@ public:
   {
     return UFixMath<NI,NF>(internal_value-((internal_type)op<<NF),true);
   }
+
 
   /** Opposite of the number.
       @return The opposite numberas a SFixMath.
@@ -580,7 +581,7 @@ inline UFixMath<sizeof(T)*8-1,0> toUInt(T val) {
     @param NF The number of bits encoding the fractional part
     @note The total number of the underlying int will be NI+NF+1 in order to accomodate the sign. It follows that, if you want something that reproduces the behavior of a int8_t, it should be declared as SFixMath<7,0>.
 */
-template<byte NI, byte NF> // NI and NF being the number of bits for the integral and the fractionnal parts respectively.
+template<byte NI, byte NF, uint64_t RANGE> // NI and NF being the number of bits for the integral and the fractionnal parts respectively.
 class SFixMath
 {
   static_assert(NI+NF<64, "The total width of a SFixMath cannot exceed 63bits");

--- a/FixMath.h
+++ b/FixMath.h
@@ -276,7 +276,7 @@ public:
   template<int8_t _NI, int8_t _NF, uint64_t _RANGE>
   //UFixMath<NI+_NI,NF+_NF, RANGE*_RANGE> operator* (const UFixMath<_NI,_NF>& op) const
   //UFixMath<NEEDEDNIMUL(NI, _NI, RANGE, _RANGE),NF+_NF, RANGE*_RANGE> operator* (const UFixMath<_NI,_NF>& op) const // TODO: check, throughfully, probably only true for UFix
-  UFixMath<NEEDEDNIEXTRA(NI+_NI, NF+_NF, RANGE*_RANGE),NF+_NF, RANGE*_RANGE> operator* (const UFixMath<_NI,_NF,_RANGE>& op) const // TODO: check, throughfully, probably only true for UFix
+  UFixMath<NEEDEDNIEXTRA(NI+_NI, NF+_NF, RANGE*_RANGE),NF+_NF, RANGE*_RANGE> operator* (const UFixMath<_NI,_NF,_RANGE>& op) const 
   {
     constexpr int8_t NEW_NI = NEEDEDNIEXTRA(NI+_NI, NF+_NF, RANGE*_RANGE);
     //typedef typename IntegerType< ((NI+_NI+NF+_NF-1)>>3)+1>::unsigned_type return_type ;
@@ -737,9 +737,9 @@ public:
   /** Opposite of the number.
       @return The opposite numberas a SFixMath.
   */
-  SFixMath<NI,NF> operator-() const
+  SFixMath<NI,NF,RANGE> operator-() const
   {
-    return SFixMath<NI,NF>(-internal_value,true);
+    return SFixMath<NI,NF,RANGE>(-internal_value,true);
   }
   
   //////// MULTIPLICATION OVERLOADS
@@ -748,9 +748,11 @@ public:
       @param op The SFixMath to be multiplied.
       @return The result of the multiplication as a SFixMath.
   */
-  template<int8_t _NI, int8_t _NF>
-  SFixMath<NI+_NI,NF+_NF> operator* (const SFixMath<_NI,_NF>& op) const
+  template<int8_t _NI, int8_t _NF, uint64_t _RANGE>
+  //SFixMath<NI+_NI,NF+_NF> operator* (const SFixMath<_NI,_NF>& op) const
+  SFixMath<NEEDEDSNIEXTRA(NI+_NI, NF+_NF, RANGE*_RANGE),NF+_NF, RANGE*_RANGE> operator* (const SFixMath<_NI,_NF,_RANGE>& op) const
   {
+    constexpr int8_t NEW_NI = NEEDEDSNIEXTRA(NI+_NI, NF+_NF, RANGE*_RANGE);
     typedef typename IntegerType<MozziPrivate::sBitsToBytes(NI+_NI+NF+_NF)>::signed_type return_type ;
     return_type tt = return_type(internal_value)*op.asRaw();
     return SFixMath<NI+_NI,NF+_NF>(tt,true);
@@ -798,7 +800,7 @@ public:
       This is still slower than a multiplication, hence the suggested workflow is to compute the inverse when time is not critical, for instance in updateControl(), and multiply it afterward, for instance in updateAudio(), if you need a division.
       @return The inverse of the number.
   */
-   SFixMath<NF,NI*2+NF> invAccurate() const
+  SFixMath<NF,MIN(NI*2+NF,62-NF)> invAccurate() const
   {
     return inv<NI*2+NF>();
     }
@@ -831,19 +833,19 @@ public:
       @return The result of the shift as a UFixMath of smaller size.
   */
   template<int8_t op>
-  SFixMath<NI-op,NF+op> sR()
+  SFixMath<MAX(NI-op,0), NF+op, RANGESHIFT(NI,op,RANGE)> sR()
   {
-    return SFixMath<NI-op,NF+op>(internal_value,true);
+    return SFixMath<MAX(NI-op,0),NF+op,RANGESHIFT(NI,op,RANGE)>(internal_value,true);
   }
 
   /** Safe and optimal left shift. The returned type will be adjusted accordingly
       @param op The shift number
       @return The result of the shift as a UFixMath of bigger size.
   */
-  template<int8_t op>
-  SFixMath<NI+op,NF-op> sL()
+template<int8_t op>
+  SFixMath<NI+op,MAX(NF-op,0),RANGESHIFT(NF,op,RANGE)> sL()
   {
-    return SFixMath<NI+op,NF-op>(internal_value,true);
+    return SFixMath<NI+op,MAX(NF-op,0)>(internal_value,true);
   }
 
 

--- a/FixMath.h
+++ b/FixMath.h
@@ -73,6 +73,7 @@
 //#define ONESBITMASK(N) ((1ULL<<(N)) - 1)
 #define FULLRANGE(N) ((1ULL<<(N)) - 1)
 #define NEEDEDNI(NI, _NI, RANGE, _RANGE) ((RANGE+_RANGE)>FULLRANGE(MAX(NI, _NI)) ? (MAX(NI, _NI)+1) : (MAX(NI, _NI)))
+#define NEEDEDNIMUL(NI, _NI, RANGE, _RANGE) ((RANGE*_RANGE)>FULLRANGE((NI+ _NI-1)) ? ((NI+ _NI)) : ((NI+ _NI-1)))
 
 // Experiments
 /*#define NBITSREAL(X,N) (abs(X) < (1<<N) ? N : NBITSREAL2(X,N+1))
@@ -256,13 +257,14 @@ public:
       @param op The UFixMath to be multiplied.
       @return The result of the multiplication as a UFixMath.
   */
-  template<byte _NI, byte _NF>
-  UFixMath<NI+_NI,NF+_NF> operator* (const UFixMath<_NI,_NF>& op) const
+  template<byte _NI, byte _NF, uint64_t _RANGE>
+  //UFixMath<NI+_NI,NF+_NF, RANGE*_RANGE> operator* (const UFixMath<_NI,_NF>& op) const
+  UFixMath<NEEDEDNIMUL(NI, _NI, RANGE, _RANGE),NF+_NF, RANGE*_RANGE> operator* (const UFixMath<_NI,_NF>& op) const // TODO: check, throughfully, probably only true for UFix
   {
     //typedef typename IntegerType< ((NI+_NI+NF+_NF-1)>>3)+1>::unsigned_type return_type ;
-    typedef typename IntegerType<MozziPrivate::uBitsToBytes(NI+_NI+NF+_NF)>::unsigned_type return_type ;
+    typedef typename IntegerType<MozziPrivate::uBitsToBytes(<NEEDEDNIMUL(NI, _NI, RANGE, _RANGE)+NF+_NF)>::unsigned_type return_type ;
     return_type tt = return_type(internal_value)*op.asRaw();
-    return UFixMath<NI+_NI,NF+_NF>(tt,true);
+    return UFixMath<<NEEDEDNIMUL(NI, _NI, RANGE, _RANGE),NF+_NF,RANGE*_RANGE>(tt,true);
   }
 
   /** Multiplication with another type. Unsafe.
@@ -1186,6 +1188,7 @@ inline SFixMath<sizeof(T)*8-1,0> toSInt(T val) {
 
 #undef MAX
 #undef FULLRANGE
+#undef NEEDEDNI
 //#undef UBITSTOBYTES
 //#undef SBITSTOBYTES
 //#undef ONESBITMASK

--- a/FixMath.h
+++ b/FixMath.h
@@ -71,6 +71,7 @@
 //#define UBITSTOBYTES(N) (((N-1)>>3)+1)
 //#define SBITSTOBYTES(N) (((N)>>3)+1)
 //#define ONESBITMASK(N) ((1ULL<<(N)) - 1)
+#define FULLRANGE(N) ((1ULL<<(N)) - 1)
 
 // Experiments
 /*#define NBITSREAL(X,N) (abs(X) < (1<<N) ? N : NBITSREAL2(X,N+1))
@@ -108,7 +109,7 @@ class SFixMath;
     @param NI The number of bits encoding the integer part. The integral part can range into [0, 2^NI -1]
     @param NF The number of bits encoding the fractional part
 */
-template<byte NI, byte NF> // NI and NF being the number of bits for the integral and the fractionnal parts respectively.
+template<byte NI, byte NF, uint64_t RANGE=FULLRANGE(NI)> // NI and NF being the number of bits for the integral and the fractionnal parts respectively.
 class UFixMath
 {
   static_assert(NI+NF<=64, "The total width of a UFixMath cannot exceed 64bits");
@@ -1181,6 +1182,7 @@ inline SFixMath<sizeof(T)*8-1,0> toSInt(T val) {
 
 
 #undef MAX
+#undef FULLRANGE
 //#undef UBITSTOBYTES
 //#undef SBITSTOBYTES
 //#undef ONESBITMASK

--- a/FixMath.h
+++ b/FixMath.h
@@ -63,6 +63,7 @@
 #ifndef FIXMATH2_H_
 #define FIXMATH2_H_
 
+
 #include<Arduino.h>
 #include "IntegerType.h"
 
@@ -223,7 +224,7 @@ public:
     return SFixMath<new_NI,new_NF,new_RANGE>(tt,true);
     }
   
-
+#ifdef FIXMATHUNSAFE
   /** Addition with another type. Unsafe
       @param op The number to be added.
       @return The result of the addition as a UFixMath.
@@ -233,7 +234,7 @@ public:
   {
     return UFixMath<NI,NF>(internal_value+((internal_type)op<<NF),true);
   }
-
+#endif
 
   //////// SUBSTRACTION OVERLOADS
 
@@ -254,7 +255,7 @@ public:
     return SFixMath<new_NI,new_NF,MAX(MOZZI_SHIFTR(RANGE,MAX(NF,_NF)-NF), MOZZI_SHIFTR(_RANGE,MAX(NF,_NF)-_NF))>(tt,true);
   }
 
-  
+  #ifdef FIXMATHUNSAFE
   /** Subtraction with another type. Unsafe
       @param op The number to be subtracted.
       @return The result of the subtraction as a UFixMath.
@@ -264,7 +265,7 @@ public:
   {
     return UFixMath<NI,NF>(internal_value-((internal_type)op<<NF),true);
   }
-
+#endif
 
   /** Opposite of the number.
       @return The opposite number as a SFixMath.
@@ -302,6 +303,7 @@ public:
     return SFixMath<NEW_NI,(NF+_NF),RANGE*_RANGE>(tt,true);
   }
 
+  #ifdef FIXMATHUNSAFE
   /** Multiplication with another type. Unsafe.
       @param op The number to be multiplied.
       @return The result of the multiplication as a UFixMath.
@@ -311,7 +313,7 @@ public:
   {
     return UFixMath<NI,NF>(internal_value*op,true);
   }
-
+#endif
 
   //////// INVERSE
 
@@ -368,6 +370,8 @@ public:
     return UFixMath<NI,NF>(internal_value>>op,true);
   }
 
+
+  #ifdef FIXMATHUNSAFE
   /** Left shift. This can overflow if you shift to a value that cannot be represented.
       Better to use .sL<shift>() if possible instead.
       @param op The shift number
@@ -377,7 +381,8 @@ public:
   {
     return UFixMath<NI,NF>(internal_value<<op,true);
   }
-
+#endif
+  
   /** Safe and optimal right shift. The returned type will be adjusted accordingly
       @param op The shift number
       @return The result of the shift as a UFixMath of smaller size.
@@ -465,7 +470,7 @@ private:
 };
 
 
-
+#ifdef FIXMATHUNSAFE
 // Multiplication
 template <int8_t NI, int8_t NF>
 inline UFixMath<NI, NF> operator*(uint8_t op, const UFixMath<NI, NF>& uf) {return uf*op;}
@@ -558,7 +563,7 @@ inline SFixMath<NI, NF> operator-(float op, const UFixMath<NI, NF>& uf) {return 
 
 template <int8_t NI, int8_t NF>
 inline SFixMath<NI, NF> operator-(double op, const UFixMath<NI, NF>& uf) {return -uf+op;}
-
+#endif
 ////// Helper functions to build SFix from a normal type automatically
 
 
@@ -685,7 +690,7 @@ public:
     return SFixMath<new_NI, new_NF, new_RANGE>(tt,true);
   }
   
-
+#ifdef FIXMATHUNSAFE
   /** Addition with another type. Unsafe
       @param op The number to be added.
       @return The result of the addition as a UFixMath.
@@ -695,7 +700,7 @@ public:
   {
     return SFixMath<NI,NF>(internal_value+(op<<NF),true);
   }
-
+#endif
 
   //////// SUBSTRACTION OVERLOADS
 
@@ -733,7 +738,7 @@ public:
     return SFixMath<new_NI, new_NF, new_RANGE>(tt,true);
   }
 
-  
+  #ifdef FIXMATHUNSAFE
   /** Subtraction with another type. Unsafe
       @param op The number to be subtracted.
       @return The result of the subtraction as a SFixMath.
@@ -743,7 +748,7 @@ public:
   {
     return SFixMath<NI,NF>(internal_value-(op<<NF),true);
     }
-
+#endif
 
   /** Opposite of the number.
       @return The opposite numberas a SFixMath.
@@ -768,6 +773,7 @@ public:
     return SFixMath<NI+_NI,NF+_NF>(tt,true);
   }
 
+  #ifdef FIXMATHUNSAFE
   /** Multiplication with another type. Unsafe.
       @param op The number to be multiplied.
       @return The result of the multiplication as a UFixMath.
@@ -777,6 +783,7 @@ public:
   {
     return SFixMath<NI,NF>(internal_value*op,true);
   }
+#endif
 
 
   //////// INVERSE
@@ -827,6 +834,7 @@ public:
     return SFixMath<NI,NF>(internal_value>>op,true);
   }
 
+  #ifdef FIXMATHUNSAFE
   /** Left shift. This can overflow if you shift to a value that cannot be represented.
       Better to use .sL<shift>() if possible instead.
       @param op The shift number
@@ -836,6 +844,7 @@ public:
   {
     return SFixMath<NI,NF>(internal_value<<op,true);
   }
+  #endif
 
   /** Safe and optimal right shift. The returned type will be adjusted accordingly
       @param op The shift number
@@ -923,6 +932,8 @@ private:
   static constexpr internal_type onesbitmask() { return (internal_type) ((1ULL<< (NI+NF)) - 1); }
 };
 
+
+#ifdef FIXMATHUNSAFE
 /// Reverse overloadings, 
 
 // Multiplication
@@ -1018,8 +1029,7 @@ inline SFixMath<NI, NF> operator-(float op, const SFixMath<NI, NF>& uf) {return 
 template <int8_t NI, int8_t NF>
 inline SFixMath<NI, NF> operator-(double op, const SFixMath<NI, NF>& uf) {return (-uf)+op;}
 
-
-
+#endif
 
 
 
@@ -1032,7 +1042,7 @@ inline SFixMath<NI, NF> operator-(double op, const SFixMath<NI, NF>& uf) {return
     @return The result of the addition of op1 and op2. As a SFixMath
 */
 template<int8_t NI, int8_t NF, uint64_t RANGE, int8_t _NI, int8_t _NF, uint64_t _RANGE>
-SFixMath<NEEDEDSNIEXTRA(MAX(NI,_NI),MAX(NF,_NF),RANGEADD(NF,_NF,RANGE,_RANGE)),MAX(NF, _NF), RANGEADD(NF,_NF,RANGE,_RANGE)> operator+ (const SFixMath<NI,NF,RANGE>& op1, const UFixMath<_NI,_NF,_RANGE>& op2 )
+inline SFixMath<NEEDEDSNIEXTRA(MAX(NI,_NI),MAX(NF,_NF),RANGEADD(NF,_NF,RANGE,_RANGE)),MAX(NF, _NF), RANGEADD(NF,_NF,RANGE,_RANGE)> operator+ (const SFixMath<NI,NF,RANGE>& op1, const UFixMath<_NI,_NF,_RANGE>& op2 )
 {
   return op2+op1;
   }


### PR DESCRIPTION
This implements what was discussed in #212 : promoting `NI` of `FixMath` only when needed. 

The approach I am landing now is to keep track of the `RANGE` actually used by the number, initialized to the maximum holdable value by default.

This will probably make heavy use of Macro, because tests will be involved (not available in C++11 constexpr), but that should be a big deal as they are just template parameters which are not used for any calculation.

This draft PR is just to keep an eye on compilations and memory usage automatically.