### PR TITLE
Non inverting ADSR

### DIFF
--- a/ADSR.h
+++ b/ADSR.h
@@ -72,7 +72,7 @@ private:
 	inline
 	void setPhase(phase * next_phase) {
 		update_step_counter = 0;
-		num_update_steps = next_phase->update_steps;
+		num_update_steps = next_phase->update_steps - LERPS_PER_CONTROL; // so that we stop slightly before, rather than slightly after the end of the phase, avoiding artefacts
 		transition.set(Q8n0_to_Q15n16(next_phase->level),next_phase->lerp_steps);
 		current_phase = next_phase;
 	}

--- a/ADSR.h
+++ b/ADSR.h
@@ -72,7 +72,7 @@ private:
 	inline
 	void setPhase(phase * next_phase) {
 		update_step_counter = 0;
-		num_update_steps = next_phase->update_steps - LERPS_PER_CONTROL; // so that we stop slightly before, rather than slightly after the end of the phase, avoiding artefacts
+		num_update_steps = next_phase->update_steps;
 		transition.set(Q8n0_to_Q15n16(next_phase->level),next_phase->lerp_steps);
 		current_phase = next_phase;
 	}
@@ -91,7 +91,7 @@ private:
 	void setTime(phase * p, unsigned int msec)
 	{
 		p->update_steps = convertMsecToControlUpdateSteps(msec);
-		p->lerp_steps = (long) p->update_steps * LERPS_PER_CONTROL;
+		p->lerp_steps = (long) p->update_steps * (LERPS_PER_CONTROL + 1); // We increase slightly the number of interpolated steps at audio rate to be sure that the transition does not over/under flow because of the approximation made by Line.
 	}
 
 
@@ -99,7 +99,7 @@ private:
 	void setUpdateSteps(phase * p, unsigned int steps)
 	{
 		p->update_steps = steps;
-		p->lerp_steps = (long) steps * LERPS_PER_CONTROL;
+		p->lerp_steps = (long) steps * (LERPS_PER_CONTROL + 1) ;
 	}
 
 


### PR DESCRIPTION
For some values of times, when using an `ADSR` updated at `MOZZI_CONTROL_RATE`, the approximation made in `Line` to compute the number of steps sometimes results in an overflow of the envelope. For instance, a long decay phase aiming for a 0 value, briefly jump to 255 (the Line does not overflow, but the conversion to `unsigned` does). This appears only for some time values, but when it does it is quite obvious (see image).

This solves this by increasing the planned number of control steps for the `Line` to reach the value (it decreases the slope of the transition slightly), to make sure that we reach an update before this phenomenon happens.

It changes very slightly the length of the envelopes (by 1/`MOZZI_CONTROL_RATE`) but this is very small compared to the error in the timing of the envelope (where a shift is used to divide by 1000).

## Testing sketch:

```
#define MOZZI_CONTROL_RATE 64
#include <Mozzi.h>
#include <Oscil.h>
#include <EventDelay.h>
#include <ADSR.h>
#include <tables/sin8192_int8.h>

Oscil<8192, MOZZI_AUDIO_RATE> aOscil(SIN8192_DATA);

EventDelay noteDelay;

ADSR<MOZZI_CONTROL_RATE, MOZZI_AUDIO_RATE> envelope;




void setup() {
  Serial.begin(115200);
  aOscil.setFreq(440);
  noteDelay.set(2000);  // 2 second countdown
  envelope.setLevels(255, 0, 0, 0);
  envelope.setTimes(10, 1000, 0, 0);
  startMozzi();
}

void updateControl() {
  envelope.update();
  if (noteDelay.ready()) {
    envelope.noteOn(true);
    noteDelay.start();
  }
}


AudioOutput updateAudio() {
  auto gain = envelope.next();
  return MonoOutput::from16Bit((int)(gain * aOscil.next()));
}



void loop() {
  audioHook();  // required here
}
```

## Result: 
Left is with the PR, Right is before
![adsr](https://github.com/sensorium/Mozzi/assets/3809674/f314200c-0f13-4dc2-abe9-b3f53f545a97)

