### PR TITLE
Remove old include<i2s.h> on MozziGuts_impl_ESP8266.hpp to avoid build failure

### DIFF
--- a/internal/MozziGuts_impl_ESP8266.hpp
+++ b/internal/MozziGuts_impl_ESP8266.hpp
@@ -48,7 +48,7 @@ uint16_t output_buffer_size = 0;
 
 #  if MOZZI_IS(MOZZI_AUDIO_MODE, MOZZI_OUTPUT_PDM_VIA_I2S)
 } // namespace MozziPrivate
-#    include <i2s.h>
+
 namespace MozziPrivate {
 inline bool canBufferAudioOutput() {
   return (i2s_available() >= MOZZI_PDM_RESOLUTION);
@@ -60,7 +60,7 @@ inline void audioOutput(const AudioOutput f) {
 }
 #  elif MOZZI_IS(MOZZI_AUDIO_MODE, MOZZI_OUTPUT_I2S_DAC)
 } // namespace MozziPrivate
-#    include <i2s.h>
+
 namespace MozziPrivate {
 inline bool canBufferAudioOutput() {
   return (i2s_available() >= MOZZI_PDM_RESOLUTION);


### PR DESCRIPTION
The include of "i2s.h" (lower case) will make compilation fail on esp8266. 

The necessary include "I2S.h" (upper case) is already on line 43.

Removing the i2s.h (lower case) will build and work with i2s for both PDM and DAC cases. 

For MOZZI_AUDIO_MODE = MOZZI_OUTPUT_PDM_VIA_I2S:
- Tested with WeMos D1 using RX (I2S output) 

For MOZZI_AUDIO_MODE = MOZZI_OUTPUT_I2S_DAC:
- Tested with Wemos D1 + PCM5102 I2S board, using IO15->BC(L)K, RX->DIN, IO02->L(R)CK.
