### PR TITLE
Centralize FixMath dependency for better portability and stricter build systems

### DIFF
--- a/AudioOutput.h
+++ b/AudioOutput.h
@@ -57,7 +57,7 @@
 
 #ifndef AUDIOOUTPUT_H
 #define AUDIOOUTPUT_H
-#include <FixMath.h>
+#include "mozzi_fixmath.h"
 
 /** The type used to store a single channel of a single frame, internally. For compatibility with earlier versions of Mozzi this is defined as int.
  *  If you do not care about keeping old sketches working, you may be able to save some RAM by using int16_t, instead (on boards where int is larger

--- a/Line.h
+++ b/Line.h
@@ -15,7 +15,7 @@
 
 #include <Arduino.h>
 
-#include<FixMath.h>
+#include "mozzi_fixmath.h"
 
 /** For linear changes with a minimum of calculation at each step. For instance,
 you can use Line to make an oscillator glide from one frequency to another,

--- a/MetaOscil.h
+++ b/MetaOscil.h
@@ -20,7 +20,6 @@
 
 #include "Oscil.h"
 #include "mozzi_fixmath.h"
-#include <FixMath.h>
 
 
 /**

--- a/Oscil.h
+++ b/Oscil.h
@@ -19,7 +19,6 @@
 #include "Arduino.h"
 #include "MozziHeadersOnly.h"
 #include "mozzi_fixmath.h"
-#include "FixMath.h"
 #include "mozzi_pgmspace.h"
 
 #ifdef OSCIL_DITHER_PHASE

--- a/mozzi_fixmath.h
+++ b/mozzi_fixmath.h
@@ -13,6 +13,7 @@
 #define FIXEDMATH_H_
 
 #include <Arduino.h>
+#include <FixMath.h>
 
 /** @defgroup fixmath Fast integer based fixed-point arithmetic
 


### PR DESCRIPTION
This set of changes addresses build issues encountered when using Mozzi with Arduino CLI and strictly structured 3rd party cores (specifically for the CH32 architecture).

The Problem:
In the original codebase, files like 'Oscil.h' and 'Line.h' included both 'mozzi_fixmath.h' (Mozzi's math abstraction) and 'FixMath.h' (the external library) explicitly. On some platforms/build systems, if the include paths are not resolved in a specific order, or if a user includes a Mozzi header that relies on FixMath types without including FixMath.h themselves, compilation fails with "unknown type" errors.

The Solution:
Moved the `#include <FixMath.h>` directive inside `mozzi_fixmath.h`.

Consequently, removed the explicit `#include <FixMath.h>` from:
- AudioOutput.h
- Line.h
- MetaOscil.h
- Oscil.h

Why this is safe and better:
1. Encapsulation: `mozzi_fixmath.h` acts as the interface for fixed-point math in Mozzi. It effectively "owns" the relationship with the underlying `FixMath` library. Consuming files shouldn't need to manually import the backend library.
2. Robustness: Any file including `mozzi_fixmath.h` is now guaranteed to have the necessary `FixMath` types defined, preventing subtle ordering bugs.
3. Compatibility: Since `FixMath.h` uses standard include guards, this change does not negatively impact existing platforms (AVR, ESP, STM32, etc.), but it fixes the build path issues on newer/stricter platforms.