### PR TITLE
Refactor FixMath inclusion for strict build environments

### DIFF
--- a/AudioOutput.h
+++ b/AudioOutput.h
@@ -57,7 +57,7 @@
 
 #ifndef AUDIOOUTPUT_H
 #define AUDIOOUTPUT_H
-#include <FixMath.h>
+#include "mozzi_fixmath.h"
 
 /** The type used to store a single channel of a single frame, internally. For compatibility with earlier versions of Mozzi this is defined as int.
  *  If you do not care about keeping old sketches working, you may be able to save some RAM by using int16_t, instead (on boards where int is larger

--- a/Line.h
+++ b/Line.h
@@ -15,7 +15,7 @@
 
 #include <Arduino.h>
 
-#include<FixMath.h>
+#include "mozzi_fixmath.h"
 
 /** For linear changes with a minimum of calculation at each step. For instance,
 you can use Line to make an oscillator glide from one frequency to another,

--- a/MetaOscil.h
+++ b/MetaOscil.h
@@ -20,7 +20,6 @@
 
 #include "Oscil.h"
 #include "mozzi_fixmath.h"
-#include <FixMath.h>
 
 
 /**

--- a/Oscil.h
+++ b/Oscil.h
@@ -19,7 +19,6 @@
 #include "Arduino.h"
 #include "MozziHeadersOnly.h"
 #include "mozzi_fixmath.h"
-#include "FixMath.h"
 #include "mozzi_pgmspace.h"
 
 #ifdef OSCIL_DITHER_PHASE

--- a/mozzi_fixmath.h
+++ b/mozzi_fixmath.h
@@ -13,6 +13,7 @@
 #define FIXEDMATH_H_
 
 #include <Arduino.h>
+#include <FixMath.h>
 
 /** @defgroup fixmath Fast integer based fixed-point arithmetic
 

--- a/mozzi_midi.h
+++ b/mozzi_midi.h
@@ -13,11 +13,9 @@
 #define MOZZI_MIDI_H_
 
 #include "mozzi_fixmath.h"
-#include "FixMath.h"
 
-#include "mozzi_pgmspace.h"
-
-/**  @brief Internal. Do not use in your sketches.
+/** @defgroup midi_frequency MIDI Frequency conversion
+Midi note number to frequency conversion functions.
 
 Internal helper class. Not intended for use in your sketches, and details may change without notic. */ 
 class MidiToFreqPrivate {


### PR DESCRIPTION
This PR centralizes the inclusion of FixMath.h inside mozzi_fixmath.h.

**Reason:**
On strictly checked build environments (like Arduino CLI with CH32 cores), explicit inclusion of FixMath.h in multiple headers caused dependency resolution issues. By making mozzi_fixmath.h the single point of entry for fixed-point math, we ensure consistent types availability and cleaner dependency management across the library.

This change is safe for existing platforms as it utilizes standard include guards.