### PR TITLE
Fix off-by-one OOB table read in Sample::next()

### DIFF
--- a/Sample.h
+++ b/Sample.h
@@ -164,7 +164,7 @@ public:
 	inline
 	int8_t next() { // 4us
 
-		if (phase_fractional>endpos_fractional){
+		if (phase_fractional>=endpos_fractional){
 			if (looping) {
 				phase_fractional = startpos_fractional + (phase_fractional - endpos_fractional);
 			}else{


### PR DESCRIPTION
`Sample::next()` uses a strict `>` comparison to decide when playback has
reached the end of the table and should wrap (looping) or stop:

```cpp
if (phase_fractional>endpos_fractional){
```

`isPlaying()` already treats `phase_fractional == endpos_fractional` as
"finished" (it uses `phase_fractional<endpos_fractional` to mean "still
playing"), so the two are inconsistent at the exact boundary.

`endpos_fractional` is set to `NUM_TABLE_CELLS << SAMPLE_F_BITS` (i.e. exactly
one past the last valid table index, in fixed-point). Because
`phase_increment_fractional` is derived from an integer frequency step, for a
lot of common frequency/table-size combinations `phase_fractional` lands
*exactly* on `endpos_fractional` after some number of calls (not just "goes
past" it). When that happens, `next()` still takes the `else` branch this
call, computes:

```cpp
unsigned int index = phase_fractional >> SAMPLE_F_BITS; // == NUM_TABLE_CELLS
out = FLASH_OR_RAM_READ<const int8_t>(table + index);
```

which reads one element past the end of `table` (and, under
`INTERP_LINEAR`, also reads `table[index+1]`, two past the end) before the
wrap/stop logic finally kicks in on the following call.

I confirmed this with a standalone harness (compiling `next()` /
`incrementPhase()` copied verbatim from this file against a real buffer with
a canary byte placed one past the array): with a 100-cell table clocked to
land exactly on `endpos_fractional`, the existing code reads the canary byte
(confirmed out-of-bounds access) once per loop cycle; under `INTERP_LINEAR`
it reads two canary bytes past the end. `examples/08.Samples/Sample_Loop_Points`
exercises exactly this full-range-plus-looping configuration against a
table (`ABOMB_DATA`, 16384 cells, no padding) where the OOB read would land
outside the array.

Changing the comparison to `>=` makes `next()` treat `phase == endpos` as
finished/wrap, matching `isPlaying()`, removes the OOB read, and does not
change behavior for the (much more common) case where phase never lands
exactly on `endpos` — `>` and `>=` are equivalent whenever equality never
occurs.

Minimal one-character fix, no behavior change other than removing the OOB
read.
